### PR TITLE
Add dark theme and use material ui inputs

### DIFF
--- a/Development/package.json
+++ b/Development/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@material-ui/core": "1.5.1",
     "@material-ui/icons": "1.1.1",
+    "@material-ui/styles": "4.3.0",
     "aor-xmysql": "^0.1.2",
     "babel-plugin-transform-es2015-destructuring": "^6.23.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/Development/src/App.js
+++ b/Development/src/App.js
@@ -23,6 +23,7 @@ import DvrIcon from '@material-ui/icons/Dvr';
 import SwapVertIcon from '@material-ui/icons/SwapVert';
 import SettingsIcon from '@material-ui/icons/Settings';
 import SettingsAppIcon from '@material-ui/icons/SettingsApplications';
+import { useTheme } from '@material-ui/styles';
 
 import MyLayout from './MyLayout';
 
@@ -32,6 +33,7 @@ const App = () => (
         icon={SettingsIcon}
         dataProvider={dataProvider}
         nestedItems={[]}
+        theme={useTheme()}
     >
         <Resource name="Settings" list={Dashboard} icon={SettingsIcon} />
         <Resource

--- a/Development/src/MyLayout.js
+++ b/Development/src/MyLayout.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Layout } from 'react-admin';
 import NestedList from './pages/menu';
+import AppBar from './pages/appbar';
 
-const MyLayout = props => <Layout {...props} menu={NestedList} />;
+const MyLayout = props => (
+    <Layout {...props} menu={NestedList} appBar={AppBar} />
+);
 
 export default MyLayout;

--- a/Development/src/components/ConnectionShowActions.js
+++ b/Development/src/components/ConnectionShowActions.js
@@ -46,11 +46,13 @@ export default function ConnectionShowActions({ basePath, data, resource }) {
                 basePath={basePath}
             />
             {data ? (
-                <NavLink to={`${basePath}/${data.id}`}>
-                    <Button label={'Edit'}>
-                        <EditIcon />
-                    </Button>
-                </NavLink>
+                <Button
+                    label={'Edit'}
+                    component={NavLink}
+                    to={`${basePath}/${data.id}`}
+                >
+                    <EditIcon />
+                </Button>
             ) : null}
         </CardActions>
     );

--- a/Development/src/components/ItemArrayField.js
+++ b/Development/src/components/ItemArrayField.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import get from 'lodash/get';
+
+const ItemArrayField = ({ className, record, source }) => (
+    <div>
+        {get(record, source).map((item, index) => (
+            <Typography key={index} className={className}>
+                {item}
+            </Typography>
+        ))}
+    </div>
+);
+ItemArrayField.defaultProps = {
+    addLabel: true,
+};
+
+export default ItemArrayField;

--- a/Development/src/components/JSONViewer.js
+++ b/Development/src/components/JSONViewer.js
@@ -11,7 +11,7 @@ import get from 'lodash/get';
 import ReactJson from 'react-json-view';
 
 // Base16 dark theme color palette
-const rjv_dark = {
+const rjvDark = {
     base00: 'rgba(0, 0, 0, 0)',
     base01: '#282828',
     base02: '#383838',
@@ -36,6 +36,11 @@ export default function JSONViewer({ endpoint, ...controllerProps }) {
         setChecked(prev => !prev);
     };
     const theme = useTheme();
+    let rjvTheme;
+    if (theme.palette.type === 'dark') {
+        rjvTheme = rjvDark;
+    } else rjvTheme = 'rjv-default';
+
     return (
         <div>
             <FormControlLabel
@@ -45,28 +50,10 @@ export default function JSONViewer({ endpoint, ...controllerProps }) {
             <Collapse in={checked}>
                 <Card>
                     <CardContent>
-                        {(() => {
-                            if (theme.palette.type === 'dark') {
-                                return (
-                                    <ReactJson
-                                        src={get(
-                                            controllerProps.record,
-                                            endpoint
-                                        )}
-                                        theme={rjv_dark}
-                                    />
-                                );
-                            } else {
-                                return (
-                                    <ReactJson
-                                        src={get(
-                                            controllerProps.record,
-                                            `${endpoint}`
-                                        )}
-                                    />
-                                );
-                            }
-                        })()}
+                        <ReactJson
+                            src={get(controllerProps.record, endpoint)}
+                            theme={rjvTheme}
+                        />
                     </CardContent>
                 </Card>
             </Collapse>

--- a/Development/src/components/JSONViewer.js
+++ b/Development/src/components/JSONViewer.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
     Card,
     CardContent,
@@ -5,15 +6,36 @@ import {
     FormControlLabel,
     Switch,
 } from '@material-ui/core';
+import { useTheme } from '@material-ui/styles';
 import get from 'lodash/get';
-import React from 'react';
 import ReactJson from 'react-json-view';
+
+// Base16 dark theme color palette
+const rjv_dark = {
+    base00: 'rgba(0, 0, 0, 0)',
+    base01: '#282828',
+    base02: '#383838',
+    base03: '#585858',
+    base04: '#b8b8b8',
+    base05: '#d8d8d8',
+    base06: '#e8e8e8',
+    base07: '#f8f8f8',
+    base08: '#be4b3c',
+    base09: '#dc9656',
+    base0A: '#f7ca88',
+    base0B: '#a1b56c',
+    base0C: '#86c1b9',
+    base0D: '#a16946',
+    base0E: '#aa759f',
+    base0F: '#7cafc2',
+};
 
 export default function JSONViewer({ endpoint, ...controllerProps }) {
     const [checked, setChecked] = React.useState(false);
     const handleChange = () => {
         setChecked(prev => !prev);
     };
+    const theme = useTheme();
     return (
         <div>
             <FormControlLabel
@@ -23,9 +45,28 @@ export default function JSONViewer({ endpoint, ...controllerProps }) {
             <Collapse in={checked}>
                 <Card>
                     <CardContent>
-                        <ReactJson
-                            src={get(controllerProps.record, endpoint)}
-                        />
+                        {(() => {
+                            if (theme.palette.type === 'dark') {
+                                return (
+                                    <ReactJson
+                                        src={get(
+                                            controllerProps.record,
+                                            endpoint
+                                        )}
+                                        theme={rjv_dark}
+                                    />
+                                );
+                            } else {
+                                return (
+                                    <ReactJson
+                                        src={get(
+                                            controllerProps.record,
+                                            `${endpoint}`
+                                        )}
+                                    />
+                                );
+                            }
+                        })()}
                     </CardContent>
                 </Card>
             </Collapse>

--- a/Development/src/components/ReceiverTransportParams.js
+++ b/Development/src/components/ReceiverTransportParams.js
@@ -10,12 +10,10 @@ import {
     TextField,
     TextInput,
 } from 'react-admin';
-import { Card, CardContent, Grid } from '@material-ui/core';
+import { Card, CardContent, Divider, Grid } from '@material-ui/core';
 import { CardFormIterator } from './CardFormIterator';
 import CheckIcon from '@material-ui/icons/Check';
 import ClearIcon from '@material-ui/icons/Clear';
-
-const HorizontalRule = () => <hr />;
 
 const MQTTReceiver = ({ dataObject }) => {
     const params_ext = Object.keys(dataObject[0]).filter(function(x) {
@@ -88,9 +86,7 @@ const MQTTReceiver = ({ dataObject }) => {
                                             label="Connection Status Broker Topic"
                                         />
                                     )}
-                                    {params_ext.length !== 0 && (
-                                        <HorizontalRule />
-                                    )}
+                                    {params_ext.length !== 0 && <Divider />}
                                     {params_ext.map(value => {
                                         return (
                                             <TextField
@@ -159,7 +155,7 @@ const MQTTReceiverEdit = ({ record }) => {
                             label="Connection Status Broker Topic"
                         />
                     )}
-                    {params_ext.length !== 0 && <HorizontalRule />}
+                    {params_ext.length !== 0 && <Divider />}
                     {params_ext.map(value => {
                         return (
                             <TextInput
@@ -229,7 +225,7 @@ const RTPReceiver = ({ dataObject }) => {
                                     )}
                                     {dataObject[i].hasOwnProperty(
                                         'fec_enabled'
-                                    ) && <HorizontalRule /> && (
+                                    ) && <Divider /> && (
                                             <BooleanField
                                                 source="fec_enabled"
                                                 label="FEC Enabled"
@@ -269,7 +265,7 @@ const RTPReceiver = ({ dataObject }) => {
                                     )}
                                     {dataObject[i].hasOwnProperty(
                                         'rtcp_enabled'
-                                    ) && <HorizontalRule /> && (
+                                    ) && <Divider /> && (
                                             <BooleanField
                                                 source="rtcp_enabled"
                                                 label="RTCP Enabled"
@@ -291,9 +287,7 @@ const RTPReceiver = ({ dataObject }) => {
                                             label="RTCP Destination Port"
                                         />
                                     )}
-                                    {params_ext.length !== 0 && (
-                                        <HorizontalRule />
-                                    )}
+                                    {params_ext.length !== 0 && <Divider />}
                                     {params_ext.map(value => {
                                         return (
                                             <TextField
@@ -396,7 +390,7 @@ const RTPReceiverEdit = ({ record }) => {
                             label="RTCP Destination Port"
                         />
                     )}
-                    {params_ext.length !== 0 && <HorizontalRule />}
+                    {params_ext.length !== 0 && <Divider />}
                     {params_ext.map(value => {
                         return (
                             <TextInput
@@ -451,9 +445,7 @@ const WebSocketReceiver = ({ dataObject }) => {
                                             label="Connection URI"
                                         />
                                     )}
-                                    {params_ext.length !== 0 && (
-                                        <HorizontalRule />
-                                    )}
+                                    {params_ext.length !== 0 && <Divider />}
                                     {params_ext.map(value => {
                                         return (
                                             <TextField
@@ -507,7 +499,7 @@ const WebSocketReceiverEdit = ({ record }) => {
                             label="Connection URI"
                         />
                     )}
-                    {params_ext.length !== 0 && <HorizontalRule />}
+                    {params_ext.length !== 0 && <Divider />}
                     {params_ext.map(value => {
                         return (
                             <TextInput

--- a/Development/src/components/SenderTransportParams.js
+++ b/Development/src/components/SenderTransportParams.js
@@ -10,12 +10,10 @@ import {
     TextField,
     TextInput,
 } from 'react-admin';
-import { Card, CardContent, Grid } from '@material-ui/core';
+import { Card, CardContent, Divider, Grid } from '@material-ui/core';
 import { CardFormIterator } from './CardFormIterator';
 import CheckIcon from '@material-ui/icons/Check';
 import ClearIcon from '@material-ui/icons/Clear';
-
-const HorizontalRule = () => <hr />;
 
 const MQTTSender = ({ dataObject }) => {
     const params_ext = Object.keys(dataObject[0]).filter(function(x) {
@@ -88,9 +86,7 @@ const MQTTSender = ({ dataObject }) => {
                                             label="Connection Status Broker Topic"
                                         />
                                     )}
-                                    {params_ext.length !== 0 && (
-                                        <HorizontalRule />
-                                    )}
+                                    {params_ext.length !== 0 && <Divider />}
                                     {params_ext.map(value => {
                                         return (
                                             <TextField
@@ -165,7 +161,7 @@ const MQTTSenderEdit = ({ record }) => {
                             label="Connection Status Broker Topic"
                         />
                     )}
-                    {params_ext.length !== 0 && <HorizontalRule />}
+                    {params_ext.length !== 0 && <Divider />}
                     {params_ext.map(value => {
                         return (
                             <TextInput
@@ -235,7 +231,7 @@ const RTPSender = ({ dataObject }) => {
                                     )}
                                     {dataObject[i].hasOwnProperty(
                                         'fec_enabled'
-                                    ) && <HorizontalRule /> && (
+                                    ) && <Divider /> && (
                                             <BooleanField
                                                 source="fec_enabled"
                                                 label="FEC Enabled"
@@ -315,7 +311,7 @@ const RTPSender = ({ dataObject }) => {
                                     )}
                                     {dataObject[i].hasOwnProperty(
                                         'rtcp_enabled'
-                                    ) && <HorizontalRule /> && (
+                                    ) && <Divider /> && (
                                             <BooleanField
                                                 source="rtcp_enabled"
                                                 label="RTCP Enabled"
@@ -345,9 +341,7 @@ const RTPSender = ({ dataObject }) => {
                                             label="RTCP Source Port"
                                         />
                                     )}
-                                    {params_ext.length !== 0 && (
-                                        <HorizontalRule />
-                                    )}
+                                    {params_ext.length !== 0 && <Divider />}
                                     {params_ext.map(value => {
                                         return (
                                             <TextField
@@ -486,7 +480,7 @@ const RTPSenderEdit = ({ record }) => {
                             label="RTCP Source Port"
                         />
                     )}
-                    {params_ext.length !== 0 && <HorizontalRule />}
+                    {params_ext.length !== 0 && <Divider />}
                     {params_ext.map(value => {
                         return (
                             <TextInput
@@ -541,9 +535,7 @@ const WebSocketSender = ({ dataObject }) => {
                                             label="Connection URI"
                                         />
                                     )}
-                                    {params_ext.length !== 0 && (
-                                        <HorizontalRule />
-                                    )}
+                                    {params_ext.length !== 0 && <Divider />}
                                     {params_ext.map(value => {
                                         return (
                                             <TextField
@@ -597,7 +589,7 @@ const WebSocketSenderEdit = ({ record }) => {
                             label="Connection URI"
                         />
                     )}
-                    {params_ext.length !== 0 && <HorizontalRule />}
+                    {params_ext.length !== 0 && <Divider />}
                     {params_ext.map(value => {
                         return (
                             <TextInput

--- a/Development/src/components/TAIField.js
+++ b/Development/src/components/TAIField.js
@@ -4,14 +4,14 @@ import get from 'lodash/get';
 import { Typography } from '@material-ui/core';
 
 const TAIField = ({ record, source }) => (
-    <Typography>
-        {get(record, source)}
+    <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+        <Typography>{get(record, source)}&emsp;</Typography>
         {get(record, source) != null && (
             <Typography color="textSecondary">
-                {TAIConversion(record, source)}
+                ({TAIConversion(record, source)})
             </Typography>
         )}
-    </Typography>
+    </div>
 );
 
 function TAIConversion(record, source) {

--- a/Development/src/components/TAIField.js
+++ b/Development/src/components/TAIField.js
@@ -1,17 +1,17 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import get from 'lodash/get';
+import { Typography } from '@material-ui/core';
 
 const TAIField = ({ record, source }) => (
-    <span style={{ fontSize: '14px' }}>
+    <Typography>
         {get(record, source)}
         {get(record, source) != null && (
-            <span style={{ color: 'grey' }}>
-                {' '}
-                ({TAIConversion(record, source)})
-            </span>
+            <Typography color="textSecondary">
+                {TAIConversion(record, source)}
+            </Typography>
         )}
-    </span>
+    </Typography>
 );
 
 function TAIConversion(record, source) {

--- a/Development/src/components/URLField.js
+++ b/Development/src/components/URLField.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import get from 'lodash/get';
+
+const UrlField = ({ source, record = {} }) => (
+    <a
+        href={get(record, source)}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ textDecoration: 'none' }}
+    >
+        <Typography color="textPrimary" style={{ textDecoration: 'underline' }}>
+            {get(record, source)}
+        </Typography>
+    </a>
+);
+UrlField.defaultProps = {
+    addLabel: true,
+};
+
+export default UrlField;

--- a/Development/src/components/URLField.js
+++ b/Development/src/components/URLField.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Typography } from '@material-ui/core';
 import get from 'lodash/get';
 
-const UrlField = ({ source, record = {} }) => (
+const URLField = ({ record, source }) => (
     <a
         href={get(record, source)}
         target="_blank"
@@ -14,8 +14,8 @@ const UrlField = ({ source, record = {} }) => (
         </Typography>
     </a>
 );
-UrlField.defaultProps = {
+URLField.defaultProps = {
     addLabel: true,
 };
 
-export default UrlField;
+export default URLField;

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -93,6 +93,9 @@ export const changePaging = newLimit => {
         return 'Default';
     }
     paging_limit = newLimit;
+    cookies.set('Paging Limit', paging_limit, {
+        path: '/',
+    });
     return paging_limit;
 };
 
@@ -440,12 +443,16 @@ export default async (type, resource, params) => {
                 resource,
                 params
             ),
-        response => {
-            return Promise.reject(
-                new Error(
-                    `${response.body.error} - ${response.body.code} - (${response.body.debug})`
-                )
-            );
+        error => {
+            if (error.body !== null) {
+                return Promise.reject(
+                    new Error(
+                        `${error.body.error} - ${error.body.code} - (${error.body.debug})`
+                    )
+                );
+            } else {
+                return Promise.reject(error);
+            }
         }
     );
 };

--- a/Development/src/index.css
+++ b/Development/src/index.css
@@ -2,6 +2,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: sans-serif;
+  overflow-y:scroll;
 }
 
 .icon {

--- a/Development/src/index.js
+++ b/Development/src/index.js
@@ -3,6 +3,12 @@ import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
 import registerServiceWorker from './registerServiceWorker';
+import { AppThemeProvider } from './theme/ThemeContext';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(
+    <AppThemeProvider>
+        <App />
+    </AppThemeProvider>,
+    document.getElementById('root')
+);
 registerServiceWorker();

--- a/Development/src/pages/Dashboard.js
+++ b/Development/src/pages/Dashboard.js
@@ -11,6 +11,7 @@ export default () => (
     <div>
         <Card>
             <Typography variant="display3" align="center">
+                {/* Non-breaking hyphen*/}
                 Welcome to the nmos&#8209;js Client
             </Typography>
             <CardContent align="center">

--- a/Development/src/pages/Dashboard.js
+++ b/Development/src/pages/Dashboard.js
@@ -10,8 +10,8 @@ import Settings from '../settings';
 export default () => (
     <div>
         <Card>
-            <Typography variant="display3" component="h2" align="center">
-                Welcome to the nmos-js Client
+            <Typography variant="display3" align="center">
+                Welcome to the nmos&#8209;js Client
             </Typography>
             <CardContent align="center">
                 <img

--- a/Development/src/pages/appbar.js
+++ b/Development/src/pages/appbar.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { AppBar } from 'react-admin';
+import { IconButton, Typography } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+import Brightness7Icon from '@material-ui/icons/Brightness7';
+import Brightness4Icon from '@material-ui/icons/Brightness4';
+import { ThemeContext } from '../theme/ThemeContext';
+import { useTheme } from '@material-ui/styles';
+
+const styles = {
+    title: {
+        flex: 1,
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+    },
+    spacer: {
+        flex: 1,
+    },
+};
+
+const CustomAppBar = withStyles(styles)(({ classes, ...props }) => {
+    const theme = useTheme();
+    let toggleThemeIcon;
+    if (theme.palette.type === 'dark') {
+        toggleThemeIcon = <Brightness7Icon />;
+    } else {
+        toggleThemeIcon = <Brightness4Icon />;
+    }
+    return (
+        <AppBar {...props}>
+            <Typography
+                variant="title"
+                color="inherit"
+                className={classes.title}
+                id="react-admin-title"
+            />
+            <span className={classes.spacer} />
+            <ThemeContext.Consumer>
+                {({ toggleTheme }) => (
+                    <IconButton color="inherit" onClick={toggleTheme}>
+                        {toggleThemeIcon}
+                    </IconButton>
+                )}
+            </ThemeContext.Consumer>
+        </AppBar>
+    );
+});
+
+export default CustomAppBar;

--- a/Development/src/pages/devices.js
+++ b/Development/src/pages/devices.js
@@ -16,7 +16,6 @@ import {
     SingleFieldList,
     TextField,
     Title,
-    UrlField,
 } from 'react-admin';
 import {
     Card,
@@ -34,6 +33,7 @@ import dataProvider from '../dataProvider';
 import PaginationButton from '../components/PaginationButton';
 import FilterField from '../components/FilterField';
 import TAIField from '../components/TAIField';
+import UrlField from '../components/URLField';
 import MapTags from '../components/TagsField';
 import '../index.css';
 import JsonIcon from '../components/JsonIcon';

--- a/Development/src/pages/devices.js
+++ b/Development/src/pages/devices.js
@@ -27,7 +27,6 @@ import {
     TableHead,
     TableRow,
 } from '@material-ui/core';
-import get from 'lodash/get';
 import Cookies from 'universal-cookie';
 import dataProvider from '../dataProvider';
 import PaginationButton from '../components/PaginationButton';
@@ -217,19 +216,6 @@ const DevicesShowActions = ({ basePath, data, resource }) => (
         <ListButton title={'Return to ' + basePath} basePath={basePath} />
     </CardActions>
 );
-
-const ItemArrayField = ({ className, source, record = {}, reference, t }) => (
-    <div style={{ fontSize: '14px' }}>
-        {get(record, source).map(item => (
-            <div key={item} className={className}>
-                {item}
-            </div>
-        ))}
-    </div>
-);
-ItemArrayField.defaultProps = {
-    addLabel: true,
-};
 
 export const DevicesShow = props => (
     <ShowController {...props}>

--- a/Development/src/pages/flows.js
+++ b/Development/src/pages/flows.js
@@ -17,7 +17,6 @@ import {
     TextField,
     Title,
 } from 'react-admin';
-import get from 'lodash/get';
 import Cookies from 'universal-cookie';
 import {
     Card,
@@ -177,18 +176,6 @@ const FlowsTitle = ({ record }) => {
                 : 'Unknown'}
         </span>
     );
-};
-
-const ItemArrayField = ({ className, source, record = {} }) => (
-    <div>
-        {get(record, source).map(item => (
-            <div key={item} className={className} />
-        ))}
-    </div>
-);
-
-ItemArrayField.defaultProps = {
-    addLabel: true,
 };
 
 const ChipConditionalLabel = ({ record, source, ...props }) => {

--- a/Development/src/pages/nodes.js
+++ b/Development/src/pages/nodes.js
@@ -24,10 +24,8 @@ import {
     TableCell,
     TableHead,
     TableRow,
-    Typography,
 } from '@material-ui/core';
 
-import get from 'lodash/get';
 import Cookies from 'universal-cookie';
 import dataProvider from '../dataProvider';
 import PaginationButton from '../components/PaginationButton';
@@ -37,6 +35,7 @@ import UrlField from '../components/URLField';
 import MapTags from '../components/TagsField';
 import ExternalLinkIcon from '@material-ui/icons/OpenInNew';
 import JsonIcon from '../components/JsonIcon';
+import ItemArrayField from '../components/ItemArrayField';
 
 const cookies = new Cookies();
 
@@ -225,20 +224,6 @@ const NodesTitle = ({ record }) => {
     );
 };
 
-const ItemArrayField = ({ className, source, record = {} }) => (
-    <div>
-        {get(record, source).map(item => (
-            <div key={item} className={className}>
-                <Typography>{item}</Typography>
-            </div>
-        ))}
-    </div>
-);
-
-ItemArrayField.defaultProps = {
-    addLabel: true,
-};
-
 const ChipConditionalLabel = ({ record, source, ...props }) => {
     props.clickable = true;
     return record ? (
@@ -347,7 +332,7 @@ export const NodesShow = props => (
                         <ArrayField source="clocks">
                             <Datagrid>
                                 <TextField source="name" />
-                                <TextField source="ref_type" />
+                                <TextField label="Ref Type" source="ref_type" />
                             </Datagrid>
                         </ArrayField>
                     )}

--- a/Development/src/pages/nodes.js
+++ b/Development/src/pages/nodes.js
@@ -14,7 +14,6 @@ import {
     SingleFieldList,
     TextField,
     Title,
-    UrlField,
 } from 'react-admin';
 import {
     Card,
@@ -25,6 +24,7 @@ import {
     TableCell,
     TableHead,
     TableRow,
+    Typography,
 } from '@material-ui/core';
 
 import get from 'lodash/get';
@@ -33,6 +33,7 @@ import dataProvider from '../dataProvider';
 import PaginationButton from '../components/PaginationButton';
 import FilterField from '../components/FilterField';
 import TAIField from '../components/TAIField';
+import UrlField from '../components/URLField';
 import MapTags from '../components/TagsField';
 import ExternalLinkIcon from '@material-ui/icons/OpenInNew';
 import JsonIcon from '../components/JsonIcon';
@@ -228,7 +229,7 @@ const ItemArrayField = ({ className, source, record = {} }) => (
     <div>
         {get(record, source).map(item => (
             <div key={item} className={className}>
-                {item}
+                <Typography>{item}</Typography>
             </div>
         ))}
     </div>

--- a/Development/src/pages/queryapis.js
+++ b/Development/src/pages/queryapis.js
@@ -102,11 +102,11 @@ export const SettingsShow = props => (
             <TextField source="name" />
             <hr />
             <RichTextField source="addresses" />
-            <TextField source="host_target" />
+            <TextField label="Host Target" source="host_target" />
             <TextField source="port" />
             <hr />
-            <TextField source="txt.api_proto" />
-            <TextField source="txt.api_ver" />
+            <TextField label="TXT Api Proto" source="txt.api_proto" />
+            <TextField labal="TXT Api Ver" source="txt.api_ver" />
             <TextField source="txt.pri" />
         </SimpleShowLayout>
     </Show>

--- a/Development/src/pages/queryapis.js
+++ b/Development/src/pages/queryapis.js
@@ -105,9 +105,9 @@ export const SettingsShow = props => (
             <TextField label="Host Target" source="host_target" />
             <TextField source="port" />
             <hr />
-            <TextField label="TXT Api Proto" source="txt.api_proto" />
-            <TextField labal="TXT Api Ver" source="txt.api_ver" />
-            <TextField source="txt.pri" />
+            <TextField label="API Protocol" source="txt.api_proto" />
+            <TextField label="API Versions" source="txt.api_ver" />
+            <TextField label="Priority" source="txt.pri" />
         </SimpleShowLayout>
     </Show>
 );

--- a/Development/src/pages/receivers.js
+++ b/Development/src/pages/receivers.js
@@ -49,6 +49,7 @@ import ConnectionShowActions from '../components/ConnectionShowActions';
 import ConnectionEditActions from '../components/ConnectionEditActions';
 import JSONViewer from '../components/JSONViewer';
 import TransportFileViewer from '../components/TransportFileViewer';
+import ItemArrayField from '../components/ItemArrayField';
 
 const cookies = new Cookies();
 
@@ -200,20 +201,6 @@ const ReceiversTitle = ({ record }) => {
                 : 'Unknown'}
         </span>
     );
-};
-
-const ItemArrayField = ({ className, source, record = {} }) => (
-    <div style={{ fontSize: '14px' }}>
-        {get(record, source).map((item, i) => (
-            <div key={i} className={className}>
-                {item}
-            </div>
-        ))}
-    </div>
-);
-
-ItemArrayField.defaultProps = {
-    addLabel: true,
 };
 
 const ChipConditionalLabel = ({ record, source, ...props }) => {

--- a/Development/src/pages/senders.js
+++ b/Development/src/pages/senders.js
@@ -22,7 +22,6 @@ import {
     TextInput,
     Title,
     Toolbar,
-    UrlField,
 } from 'react-admin';
 import get from 'lodash/get';
 import set from 'lodash/set';
@@ -46,6 +45,7 @@ import dataProvider from '../dataProvider';
 import PaginationButton from '../components/PaginationButton';
 import FilterField from '../components/FilterField';
 import TAIField from '../components/TAIField';
+import UrlField from '../components/URLField';
 import MapTags from '../components/TagsField';
 import JsonIcon from '../components/JsonIcon';
 import SenderTransportParamsCardsGrid from '../components/SenderTransportParams';
@@ -201,7 +201,7 @@ const ItemArrayField = ({ className, source, record = {} }) => (
     <div style={{ fontSize: '14px' }}>
         {get(record, source).map((item, i) => (
             <div key={i} className={className}>
-                {item}
+                <Typography>{item}</Typography>
             </div>
         ))}
     </div>

--- a/Development/src/pages/senders.js
+++ b/Development/src/pages/senders.js
@@ -52,6 +52,7 @@ import SenderTransportParamsCardsGrid from '../components/SenderTransportParams'
 import ConnectionShowActions from '../components/ConnectionShowActions';
 import ConnectionEditActions from '../components/ConnectionEditActions';
 import JSONViewer from '../components/JSONViewer';
+import ItemArrayField from '../components/ItemArrayField';
 
 const cookies = new Cookies();
 
@@ -197,20 +198,6 @@ const SendersTitle = ({ record }) => {
     );
 };
 
-const ItemArrayField = ({ className, source, record = {} }) => (
-    <div style={{ fontSize: '14px' }}>
-        {get(record, source).map((item, i) => (
-            <div key={i} className={className}>
-                <Typography>{item}</Typography>
-            </div>
-        ))}
-    </div>
-);
-
-ItemArrayField.defaultProps = {
-    addLabel: true,
-};
-
 const ChipConditionalLabel = ({ record, source, ...props }) => {
     props.clickable = true;
     return record ? (
@@ -251,14 +238,18 @@ export const SendersShow = props => {
                                 component={Link}
                                 to={`${props.basePath}/${props.id}/show/staged`}
                             />
-                            {get(controllerProps.record, '$transportfile') && (
-                                <Tab
-                                    label="Transport File"
-                                    value={`${props.match.url}/transportfile`}
-                                    component={Link}
-                                    to={`${props.basePath}/${props.id}/show/transportfile`}
-                                />
-                            )}
+                            <Tab
+                                label="Transport File"
+                                disabled={
+                                    !get(
+                                        controllerProps.record,
+                                        '$transportfile'
+                                    )
+                                }
+                                value={`${props.match.url}/transportfile`}
+                                component={Link}
+                                to={`${props.basePath}/${props.id}/show/transportfile`}
+                            />
                         </Tabs>
                     </AppBar>
                     <Route
@@ -296,8 +287,7 @@ export const SendersShow = props => {
                         path={`${props.basePath}/${props.id}/show/transportfile`}
                         render={() => (
                             <ShowTransportFileTab
-                                {...props}
-                                controllerProps={controllerProps}
+                                record={controllerProps.record}
                             />
                         )}
                     />
@@ -462,10 +452,10 @@ const ShowStagedTab = ({ controllerProps, ...props }) => {
     );
 };
 
-const ShowTransportFileTab = ({ controllerProps, ...props }) => {
+const ShowTransportFileTab = ({ record }) => {
     const [open, setOpen] = React.useState(false);
     const handleClick = () => {
-        copy(get(controllerProps.record, `$transportfile`)).then(() => {
+        copy(get(record, `$transportfile`)).then(() => {
             setOpen(true);
         });
     };
@@ -474,17 +464,14 @@ const ShowTransportFileTab = ({ controllerProps, ...props }) => {
     };
     return (
         <ShowView
-            {...props}
-            {...controllerProps}
+            record={record}
             title={<SendersTitle />}
             actions={<ConnectionShowActions />}
         >
             <SimpleShowLayout>
-                <Typography>
-                    <pre style={{ fontFamily: 'inherit' }}>
-                        {get(controllerProps.record, '$transportfile')}
-                    </pre>
-                </Typography>
+                <pre style={{ fontFamily: 'inherit' }}>
+                    <Typography>{get(record, '$transportfile')}</Typography>
+                </pre>
                 <MaterialButton
                     variant="contained"
                     color="primary"

--- a/Development/src/pages/sources.js
+++ b/Development/src/pages/sources.js
@@ -17,7 +17,6 @@ import {
     TextField,
     Title,
 } from 'react-admin';
-import get from 'lodash/get';
 import Cookies from 'universal-cookie';
 import {
     Card,
@@ -176,17 +175,6 @@ const SourcesTitle = ({ record }) => {
                 : 'Unknown'}
         </span>
     );
-};
-const ItemArrayField = ({ className, source, record = {} }) => (
-    <div>
-        {get(record, source).map(item => (
-            <div key={item} className={className} />
-        ))}
-    </div>
-);
-
-ItemArrayField.defaultProps = {
-    addLabel: true,
 };
 
 const ChipConditionalLabel = ({ record, source, ...props }) => {

--- a/Development/src/pages/subscriptions.js
+++ b/Development/src/pages/subscriptions.js
@@ -9,7 +9,6 @@ import {
     SimpleShowLayout,
     TextField,
     Title,
-    UrlField,
 } from 'react-admin';
 import { hr } from '@material-ui/core';
 import Cookies from 'universal-cookie';
@@ -26,6 +25,7 @@ import {
 import dataProvider from '../dataProvider';
 import PaginationButton from '../components/PaginationButton';
 import FilterField from '../components/FilterField';
+import UrlField from '../components/URLField';
 import MapTags from '../components/TagsField';
 import JsonIcon from '../components/JsonIcon';
 

--- a/Development/src/settings.js
+++ b/Development/src/settings.js
@@ -1,314 +1,197 @@
 import React from 'react';
-import Snackbar from '@material-ui/core/Snackbar';
+import {
+    Button,
+    FormControlLabel,
+    List,
+    ListItem,
+    MenuItem,
+    Snackbar,
+    Switch,
+    TextField,
+} from '@material-ui/core';
+import { useTheme as themeHook } from '@material-ui/styles';
+import { withStyles } from '@material-ui/core/styles';
 import Cookies from 'universal-cookie';
 
 import { changePaging, returnChangeQuery } from './dataProvider';
-import { FormControlLabel, Switch } from '@material-ui/core';
+import { useTheme } from './theme/ThemeContext';
 
 const cookies = new Cookies();
-let x = '';
 
-class Settings extends React.Component {
-    state = {
-        open: false,
-        vertical: 'top',
-        horizontal: 'center',
-        checked: false,
-        rql: this.getBool(cookies.get('RQL')),
-        theme: 'light',
-    };
+const styles = theme => ({
+    container: {
+        justifyContent: 'center',
+        display: 'flex',
+        flexWrap: 'wrap',
+    },
+    listItem: {
+        justifyContent: 'center',
+    },
+    textField: {
+        marginLeft: theme.spacing.unit,
+        marginRight: theme.spacing.unit,
+        width: 350,
+    },
+});
 
-    getBool(cookie) {
-        if (cookie === 'false') {
-            return false;
-        } else {
-            return true;
-        }
-    }
+const paging = [
+    {
+        value: 5,
+        label: '5',
+    },
+    {
+        value: 10,
+        label: '10',
+    },
+    {
+        value: 20,
+        label: '20',
+    },
+    {
+        value: 50,
+        label: '50',
+    },
+    {
+        value: 100,
+        label: '100',
+    },
+];
 
-    handleClickQuery = state => () => {
-        this.setState({ open: true, ...state });
-        this.queryApiSave();
-    };
-
-    handeClickResetQuery = state => () => {
-        this.setState({ open: true, ...state });
-        this.queryApiReset();
-    };
-
-    handleClickEvents = state => () => {
-        this.setState({ open: true, ...state });
-        this.eventFunctionSave();
-    };
-
-    handleClickResetEvents = state => () => {
-        this.setState({ open: true, ...state });
-        this.eventFunctionReset();
-    };
-
-    handleClickDns = state => () => {
-        this.setState({ open: true, ...state });
-        this.dnsSave();
-    };
-
-    handleClickResetDns = state => () => {
-        this.setState({ open: true, ...state });
-        this.dnsReset();
-    };
-
-    handleClickPaging = state => () => {
-        this.setState({ open: true, ...state });
-        this.pagingSave();
-    };
-
-    handleClickResetPaging = state => () => {
-        this.setState({ open: true, ...state });
-        this.pagingReset();
-    };
-
-    handleClose = reason => {
-        if (reason === 'clickaway') {
-            return;
-        }
-        this.setState({ open: false });
-    };
-
-    advancedRqlMode = state => event => {
-        this.setState({ rql: event.target.checked }, function() {
-            if (!this.state.rql) {
-                cookies.set('RQL', false, { path: '/' });
-                x = 'RQL Disabled';
-            }
-            if (this.state.rql) {
-                cookies.set('RQL', true, { path: '/' });
-                x = 'RQL Enabled';
-            }
-            this.setState({ open: true, ...state });
-        });
-    };
-
-    queryApiSave = () => {
-        x = document.getElementById('queryApiInput').value;
-        document.getElementById('queryApiInput').placeholder = x;
-        returnChangeQuery('Query API', x);
-    };
-
-    queryApiReset = () => {
-        x = returnChangeQuery('Query API', 'reset');
-        document.getElementById('queryApiInput').value = x;
-    };
-
-    eventFunctionSave = () => {
-        x = document.getElementById('loggingApiInput').value;
-        document.getElementById('loggingApiInput').placeholder = x;
-        returnChangeQuery('Logging API', x);
-    };
-
-    eventFunctionReset = () => {
-        x = returnChangeQuery('Logging API', 'reset');
-        document.getElementById('loggingApiInput').value = x;
-    };
-
-    dnsSave = () => {
-        x = document.getElementById('dnsApiInput').value;
-        document.getElementById('dnsApiInput').placeholder = x;
-        returnChangeQuery('DNS-SD API', x);
-    };
-
-    dnsReset = () => {
-        x = returnChangeQuery('DNS-SD API', 'reset');
-        document.getElementById('dnsApiInput').value = x;
-    };
-
-    pagingSave = () => {
-        x = document.getElementById('pagingLimitInput').value;
-        document.getElementById('pagingLimitInput').placeholder = x;
-        changePaging(x);
-        cookies.set('Paging Limit', x, { path: '/' });
-    };
-
-    pagingReset = () => {
-        x = null;
-        document.getElementById('pagingLimitInput').value = x;
-        document.getElementById('pagingLimitInput').placeholder = 'Default';
-        changePaging(undefined);
-        cookies.set('Paging Limit', '', { path: '/' });
-    };
-
-    handleChange = name => event => {
-        this.setState({ [name]: event.target.checked });
-        this.invert();
-    };
-
-    handleChangeRQL = name => event => {
-        this.setState({ [name]: event.target.checked }, () => {
-            this.advancedRqlMode(this.state.rql);
-        });
-    };
-
-    invert() {
-        if (this.state.theme === 'light') {
-            this.setState({ theme: 'dark' });
-            document.documentElement.style.webkitFilter = 'invert(90%)';
-            document.getElementById('sealion').style.webkitFilter =
-                'invert(90%)';
-        } else {
-            this.setState({ theme: 'light' });
-            document.documentElement.style.webkitFilter = 'invert(0)';
-            document.getElementById('sealion').style.webkitFilter = 'invert(0)';
-        }
-    }
-
-    render() {
-        const { vertical, horizontal, open } = this.state;
-        return (
-            <div>
-                <div style={{ display: 'block' }}>
-                    <h5>
-                        Query API &nbsp;
-                        <input
-                            type="text"
-                            id="queryApiInput"
-                            size="35"
-                            style={{
-                                borderRadius: '3px',
-                                border: 'solid 1px grey',
-                            }}
-                            defaultValue={returnChangeQuery('Query API', '')}
-                        />
-                        <input
-                            type="button"
-                            id="myButton5"
-                            value="Save"
-                            onClick={this.handleClickQuery({
-                                vertical: 'top',
-                                horizontal: 'center',
-                            })}
-                        />
-                        <input
-                            type="button"
-                            id="myResetButton"
-                            value="Reset"
-                            onClick={this.handeClickResetQuery()}
-                        />
-                    </h5>
-                </div>
-
-                <div style={{ display: 'block' }}>
-                    <h5>
-                        Logging API &nbsp;
-                        <input
-                            type="text"
-                            id="loggingApiInput"
-                            size="35"
-                            style={{
-                                borderRadius: '3px',
-                                border: 'solid 1px grey',
-                            }}
-                            defaultValue={returnChangeQuery('Logging API', '')}
-                        />
-                        <input
-                            type="button"
-                            id="myButton3"
-                            value="Save"
-                            onClick={this.handleClickEvents({
-                                vertical: 'top',
-                                horizontal: 'center',
-                            })}
-                        />
-                        <input
-                            type="button"
-                            id="myButton4"
-                            value="Reset"
-                            onClick={this.handleClickResetEvents()}
-                        />
-                    </h5>
-                </div>
-
-                <div style={{ display: 'block' }}>
-                    <h5>
-                        DNS-SD API &nbsp;
-                        <input
-                            type="text"
-                            id="dnsApiInput"
-                            size="35"
-                            style={{
-                                borderRadius: '3px',
-                                border: 'solid 1px grey',
-                            }}
-                            defaultValue={returnChangeQuery('DNS-SD API', '')}
-                        />
-                        <input
-                            type="button"
-                            id="myButton7"
-                            value="Save"
-                            onClick={this.handleClickDns({
-                                vertical: 'top',
-                                horizontal: 'center',
-                            })}
-                        />
-                        <input
-                            type="button"
-                            id="myButton8"
-                            value="Reset"
-                            onClick={this.handleClickResetDns()}
-                        />
-                    </h5>
-                </div>
-
-                <div style={{ display: 'block' }}>
-                    <h5>
-                        Paging Limit &nbsp;
-                        <input
-                            type="number"
-                            id="pagingLimitInput"
-                            size="35"
-                            style={{
-                                borderRadius: '3px',
-                                border: 'solid 1px grey',
-                            }}
-                            placeholder={changePaging('valueRequest')}
-                        />
-                        <input
-                            type="button"
-                            id="myButton9"
-                            value="Save"
-                            onClick={this.handleClickPaging({
-                                vertical: 'top',
-                                horizontal: 'center',
-                            })}
-                        />
-                        <input
-                            type="button"
-                            id="myButton10"
-                            value="Reset"
-                            onClick={this.handleClickResetPaging()}
-                        />
-                    </h5>
-                </div>
-
-                <FormControlLabel
-                    control={
-                        <Switch
-                            checked={this.state.rql}
-                            onClick={this.advancedRqlMode(
-                                this.state.rql.toString()
-                            )}
-                        />
-                    }
-                    label="RQL"
-                />
-                <Snackbar
-                    anchorOrigin={{ vertical, horizontal }}
-                    open={open}
-                    autoHideDuration={1600}
-                    onClose={this.handleClose}
-                    ContentProps={{ 'aria-describedby': 'myText' }}
-                    message={<span id="text">{x}</span>}
-                />
-            </div>
-        );
-    }
+function getBool(cookie) {
+    return cookie !== 'false';
 }
 
-export default Settings;
+const Settings = props => {
+    const theme = themeHook();
+    const { classes } = props;
+    const [values, setValues] = React.useState({
+        queryAPI: returnChangeQuery('Query API', ''),
+        loggingAPI: returnChangeQuery('Logging API', ''),
+        dnssdAPI: returnChangeQuery('DNS-SD API', ''),
+        paging: parseInt(changePaging('valueRequest'), 10),
+        rql: getBool(cookies.get('RQL')),
+        darkTheme: theme.palette.type === 'dark',
+    });
+
+    const handleInputChange = name => event => {
+        setValues({ ...values, [name]: event.target.value });
+    };
+    const handleSwitchChange = name => () => {
+        setValues({ ...values, [name]: !values[name] });
+    };
+
+    const [open, setOpen] = React.useState(false);
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    const themeToggle = useTheme();
+
+    const handleSave = () => {
+        returnChangeQuery('Query API', values.queryAPI);
+        returnChangeQuery('Logging API', values.loggingAPI);
+        returnChangeQuery('DNS-SD API', values.dnssdAPI);
+        if (values.darkTheme !== (theme.palette.type === 'dark')) {
+            themeToggle.toggle();
+        }
+        if (values.paging) {
+            changePaging(values.paging);
+        }
+        cookies.set('RQL', values.rql, { path: '/' });
+        setOpen(true);
+    };
+
+    return (
+        <form
+            className={classes.container}
+            noValidate
+            autoComplete="off"
+            title=""
+        >
+            <List>
+                <ListItem>
+                    <TextField
+                        id="standard-queryAPI"
+                        label="Query API"
+                        value={values.queryAPI}
+                        onChange={handleInputChange('queryAPI')}
+                        className={classes.textField}
+                    />
+                </ListItem>
+                <ListItem>
+                    <TextField
+                        id="standard-loggingAPI"
+                        label="Logging API"
+                        value={values.loggingAPI}
+                        onChange={handleInputChange('loggingAPI')}
+                        className={classes.textField}
+                    />
+                </ListItem>
+                <ListItem>
+                    <TextField
+                        id="standard-dnssdAPI"
+                        label="DNS-SD API"
+                        value={values.dnssdAPI}
+                        onChange={handleInputChange('dnssdAPI')}
+                        className={classes.textField}
+                    />
+                </ListItem>
+                <ListItem className={classes.listItem}>
+                    <TextField
+                        id="standard-paging"
+                        select
+                        label="Paging Limit"
+                        placeholder=""
+                        className={classes.textField}
+                        value={values.paging}
+                        onChange={handleInputChange('paging')}
+                        margin="normal"
+                    >
+                        {paging.map(option => (
+                            <MenuItem key={option.value} value={option.value}>
+                                {option.label}
+                            </MenuItem>
+                        ))}
+                    </TextField>
+                </ListItem>
+                <ListItem className={classes.listItem}>
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={values.darkTheme}
+                                onChange={handleSwitchChange('darkTheme')}
+                                color="primary"
+                            />
+                        }
+                        label="Dark Theme"
+                    />
+                    <FormControlLabel
+                        control={
+                            <Switch
+                                checked={values.rql}
+                                onChange={handleSwitchChange('rql')}
+                                color="primary"
+                            />
+                        }
+                        label="RQL"
+                    />
+                </ListItem>
+                <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleSave}
+                >
+                    Save
+                </Button>
+            </List>
+            <Snackbar
+                open={open}
+                onClose={handleClose}
+                autoHideDuration={3000}
+                message={<span>Saved</span>}
+            />
+        </form>
+    );
+};
+
+export default withStyles(styles)(Settings);

--- a/Development/src/settings.js
+++ b/Development/src/settings.js
@@ -9,12 +9,10 @@ import {
     Switch,
     TextField,
 } from '@material-ui/core';
-import { useTheme as themeHook } from '@material-ui/styles';
 import { withStyles } from '@material-ui/core/styles';
 import Cookies from 'universal-cookie';
 
 import { changePaging, returnChangeQuery } from './dataProvider';
-import { useTheme } from './theme/ThemeContext';
 
 const cookies = new Cookies();
 
@@ -62,7 +60,6 @@ function getBool(cookie) {
 }
 
 const Settings = props => {
-    const theme = themeHook();
     const { classes } = props;
     const [values, setValues] = React.useState({
         queryAPI: returnChangeQuery('Query API', ''),
@@ -70,7 +67,6 @@ const Settings = props => {
         dnssdAPI: returnChangeQuery('DNS-SD API', ''),
         paging: parseInt(changePaging('valueRequest'), 10),
         rql: getBool(cookies.get('RQL')),
-        darkTheme: theme.palette.type === 'dark',
     });
 
     const handleInputChange = name => event => {
@@ -85,15 +81,10 @@ const Settings = props => {
         setOpen(false);
     };
 
-    const themeToggle = useTheme();
-
     const handleSave = () => {
         returnChangeQuery('Query API', values.queryAPI);
         returnChangeQuery('Logging API', values.loggingAPI);
         returnChangeQuery('DNS-SD API', values.dnssdAPI);
-        if (values.darkTheme !== (theme.palette.type === 'dark')) {
-            themeToggle.toggle();
-        }
         if (values.paging) {
             changePaging(values.paging);
         }
@@ -158,16 +149,6 @@ const Settings = props => {
                     <FormControlLabel
                         control={
                             <Switch
-                                checked={values.darkTheme}
-                                onChange={handleSwitchChange('darkTheme')}
-                                color="primary"
-                            />
-                        }
-                        label="Dark Theme"
-                    />
-                    <FormControlLabel
-                        control={
-                            <Switch
                                 checked={values.rql}
                                 onChange={handleSwitchChange('rql')}
                                 color="primary"
@@ -176,13 +157,15 @@ const Settings = props => {
                         label="RQL"
                     />
                 </ListItem>
-                <Button
-                    variant="contained"
-                    color="primary"
-                    onClick={handleSave}
-                >
-                    Save
-                </Button>
+                <ListItem className={classes.listItem}>
+                    <Button
+                        variant="contained"
+                        color="primary"
+                        onClick={handleSave}
+                    >
+                        Save
+                    </Button>
+                </ListItem>
             </List>
             <Snackbar
                 open={open}

--- a/Development/src/theme/ThemeContext.js
+++ b/Development/src/theme/ThemeContext.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import { ThemeProvider } from '@material-ui/styles';
 import { createMuiTheme } from '@material-ui/core/styles';
-import { lightBlue } from '@material-ui/core/colors';
+import { blue, lightBlue } from '@material-ui/core/colors';
 import Cookies from 'universal-cookie';
 
 const cookies = new Cookies();
 
-const ThemeToggleContext = React.createContext('light');
-export const useTheme = () => React.useContext(ThemeToggleContext);
+export const ThemeContext = React.createContext({
+    theme: 'light',
+    toggleTheme: () => {},
+});
 
 export const AppThemeProvider = ({ children }) => {
     const [themeState, setThemeState] = React.useState({
@@ -18,7 +20,7 @@ export const AppThemeProvider = ({ children }) => {
     const theme = createMuiTheme({
         palette: {
             primary: lightBlue,
-            secondary: lightBlue,
+            secondary: blue,
             type: themeState.mode,
         },
     });
@@ -30,12 +32,12 @@ export const AppThemeProvider = ({ children }) => {
     };
 
     return (
-        <ThemeToggleContext.Provider value={{ toggle: toggleTheme }}>
+        <ThemeContext.Provider
+            value={{ theme: themeState.mode, toggleTheme: toggleTheme }}
+        >
             <ThemeProvider theme={theme}>
                 {React.cloneElement(children, { theme: theme })}
             </ThemeProvider>
-        </ThemeToggleContext.Provider>
+        </ThemeContext.Provider>
     );
 };
-
-export default AppThemeProvider;

--- a/Development/src/theme/ThemeContext.js
+++ b/Development/src/theme/ThemeContext.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ThemeProvider } from '@material-ui/styles';
+import { createMuiTheme } from '@material-ui/core/styles';
+import { lightBlue } from '@material-ui/core/colors';
+import Cookies from 'universal-cookie';
+
+const cookies = new Cookies();
+
+const ThemeToggleContext = React.createContext('light');
+export const useTheme = () => React.useContext(ThemeToggleContext);
+
+export const AppThemeProvider = ({ children }) => {
+    const [themeState, setThemeState] = React.useState({
+        mode: cookies.get('theme'),
+    });
+    if (themeState.mode === undefined) setThemeState({ mode: 'light' });
+
+    const theme = createMuiTheme({
+        palette: {
+            primary: lightBlue,
+            secondary: lightBlue,
+            type: themeState.mode,
+        },
+    });
+
+    const toggleTheme = () => {
+        const mode = themeState.mode === 'light' ? `dark` : `light`;
+        cookies.set('theme', mode);
+        setThemeState({ mode: mode });
+    };
+
+    return (
+        <ThemeToggleContext.Provider value={{ toggle: toggleTheme }}>
+            <ThemeProvider theme={theme}>
+                {React.cloneElement(children, { theme: theme })}
+            </ThemeProvider>
+        </ThemeToggleContext.Provider>
+    );
+};
+
+export default AppThemeProvider;

--- a/Development/yarn.lock
+++ b/Development/yarn.lock
@@ -173,7 +173,7 @@
     rifm "^0.7.0"
     tslib "^1.9.3"
 
-"@material-ui/styles@^4.2.0":
+"@material-ui/styles@4.3.0", "@material-ui/styles@^4.2.0":
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.3.0.tgz#27f11fbf061d8a20ad5703acb0dbb0e69cc00345"
   integrity sha512-7yOu+IOvbTVM+LfFJ0c7RZKksSpi2PmPwMhVnAKo1Ca3Nadjd950ALL6WG+R/W3C3GqakUvOqA5OLMvN/8N2jg==


### PR DESCRIPTION
- The settings page has been re-written to have a theme consistent with
  the rest of the app using material ui inputs.
- A dark theme has been added and theming inconsistencies removed.
- HTTP errors returned when the query API is not found will no longer
  crash the entire app.
- The scrollbar is always shown on PC to prevent jarring motion.