### PR TITLE
Fetch from multiple connection API URLs 

### DIFF
--- a/Development/src/components/ConnectionShowActions.js
+++ b/Development/src/components/ConnectionShowActions.js
@@ -18,15 +18,8 @@ export default function ConnectionShowActions({ basePath, data, resource }) {
     if (data) {
         const tab = window.location.href.split('/').pop();
         json_href = cookies.get('Query API') + '/' + resource + '/' + data.id;
-        if (tab === 'active' || tab === 'staged') {
-            json_href =
-                data.$connectionAPI +
-                '/single/' +
-                resource +
-                '/' +
-                data.id +
-                '/' +
-                tab;
+        if (tab === 'active' || tab === 'staged' || tab === 'transportfile') {
+            json_href = data.$connectionAPI + '/' + tab;
         }
     }
     return (

--- a/Development/src/components/ConnectionShowActions.js
+++ b/Development/src/components/ConnectionShowActions.js
@@ -3,6 +3,7 @@ import { Button, ListButton } from 'ra-ui-materialui';
 import React from 'react';
 import NavLink from 'react-router-dom/NavLink';
 import EditIcon from '@material-ui/icons/Edit';
+import get from 'lodash/get';
 import Cookies from 'universal-cookie';
 import JsonIcon from './JsonIcon';
 
@@ -38,7 +39,7 @@ export default function ConnectionShowActions({ basePath, data, resource }) {
                 title={'Return to ' + basePath}
                 basePath={basePath}
             />
-            {data ? (
+            {get(data, '$connectionAPI') != null ? (
                 <Button
                     label={'Edit'}
                     component={NavLink}

--- a/Development/src/components/TransportFileViewer.js
+++ b/Development/src/components/TransportFileViewer.js
@@ -41,10 +41,8 @@ const TransportFileViewer = ({ endpoint, ...props }) => {
             <Collapse in={checked}>
                 <Card>
                     <CardContent>
-                        <Typography>
-                            <pre style={{ fontFamily: 'inherit' }}>
-                                {get(props.record, `${endpoint}`)}
-                            </pre>
+                        <Typography style={{ fontFamily: 'inherit' }}>
+                            {get(props.record, `${endpoint}`)}
                         </Typography>
                         <MaterialButton
                             variant="contained"

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -410,10 +410,7 @@ async function convertHTTPResponseToDataProvider(
                     }
                 });
                 // Return IS-04 if no Connection API endpoints
-                if (
-                    Object.keys(connectionAddresses).length === 0 &&
-                    connectionAddresses.constructor === Object
-                ) {
+                if (Object.keys(connectionAddresses).length === 0) {
                     return { url: url, data: json };
                 }
 

--- a/Development/src/pages/receivers.js
+++ b/Development/src/pages/receivers.js
@@ -236,18 +236,23 @@ export const ReceiversShow = props => {
                                 component={Link}
                                 to={`${props.basePath}/${props.id}/show/`}
                             />
-                            <Tab
-                                label="Active"
-                                value={`${props.match.url}/active`}
-                                component={Link}
-                                to={`${props.basePath}/${props.id}/show/active`}
-                            />
-                            <Tab
-                                label="Staged"
-                                value={`${props.match.url}/staged`}
-                                component={Link}
-                                to={`${props.basePath}/${props.id}/show/staged`}
-                            />
+                            {get(controllerProps.record, '$connectionAPI') !==
+                                undefined &&
+                                ['active', 'staged'].map(label => (
+                                    <Tab
+                                        key={label}
+                                        label={label}
+                                        value={`${props.match.url}/${label}`}
+                                        component={Link}
+                                        to={`${props.basePath}/${props.id}/show/${label}`}
+                                        disabled={
+                                            !get(
+                                                controllerProps.record,
+                                                `$${label}`
+                                            )
+                                        }
+                                    />
+                                ))}
                         </Tabs>
                     </AppBar>
                     <Route

--- a/Development/src/pages/senders.js
+++ b/Development/src/pages/senders.js
@@ -226,30 +226,25 @@ export const SendersShow = props => {
                                 component={Link}
                                 to={`${props.basePath}/${props.id}/show/`}
                             />
-                            <Tab
-                                label="Active"
-                                value={`${props.match.url}/active`}
-                                component={Link}
-                                to={`${props.basePath}/${props.id}/show/active`}
-                            />
-                            <Tab
-                                label="Staged"
-                                value={`${props.match.url}/staged`}
-                                component={Link}
-                                to={`${props.basePath}/${props.id}/show/staged`}
-                            />
-                            <Tab
-                                label="Transport File"
-                                disabled={
-                                    !get(
-                                        controllerProps.record,
-                                        '$transportfile'
+                            {get(controllerProps.record, '$connectionAPI') !==
+                                undefined &&
+                                ['active', 'staged', 'transportfile'].map(
+                                    label => (
+                                        <Tab
+                                            key={label}
+                                            value={`${props.match.url}/${label}`}
+                                            component={Link}
+                                            to={`${props.basePath}/${props.id}/show/${label}`}
+                                            disabled={
+                                                !get(
+                                                    controllerProps.record,
+                                                    `$${label}`
+                                                )
+                                            }
+                                            label={label}
+                                        />
                                     )
-                                }
-                                value={`${props.match.url}/transportfile`}
-                                component={Link}
-                                to={`${props.basePath}/${props.id}/show/transportfile`}
-                            />
+                                )}
                         </Tabs>
                     </AppBar>
                     <Route


### PR DESCRIPTION
- Attempt to fetch from each connection API URL until successful. This
  fits the case where the node is not accessible on some network
  interfaces.
- Error handling in the dataProvider will no longer crash the app.
- The Active, Staged and Transportfile tabs are now shown conditionally.
  If no controls are found the tabs are not shown, if unable to connect
  to controls, the tabs are disabled. This change also applies to the
  edit button.
- A warning has been fixed for nesting a `<pre>` inside `<Typography>`