### PR TITLE
Correctly format times

### DIFF
--- a/Development/package.json
+++ b/Development/package.json
@@ -11,7 +11,7 @@
     "babel-plugin-transform-es2015-destructuring": "^6.23.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "clipboard-copy": "^3.1.0",
-    "dayjs": "^1.8.14",
+    "dayjs": "^1.8.16",
     "deep-diff": "^1.0.2",
     "json-ptr": "^1.2.0",
     "lodash": "^4.17.15",
@@ -25,6 +25,7 @@
     "react-json-view": "^1.19.1",
     "react-router-dom": "^4.3.1",
     "react-scripts": "1.1.5",
+    "t-a-i": "^1.0.15",
     "tslint": "^5.17.0",
     "universal-cookie": "^3.0.7",
     "webpack": "^3.11.0"

--- a/Development/src/components/TAIField.js
+++ b/Development/src/components/TAIField.js
@@ -1,26 +1,37 @@
 import React from 'react';
+import tai from 't-a-i';
 import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
 import get from 'lodash/get';
 import { Typography } from '@material-ui/core';
+dayjs.extend(utc);
 
-const TAIField = ({ record, source }) => (
+const TAIField = ({ record, source, mode }) => (
     <div style={{ display: 'flex', flexWrap: 'wrap' }}>
         <Typography>{get(record, source)}&emsp;</Typography>
         {get(record, source) != null && (
             <Typography color="textSecondary">
-                ({TAIConversion(record, source)})
+                ({TAIConversion(record, source, mode)})
             </Typography>
         )}
     </div>
 );
 
-function TAIConversion(record, source) {
-    const taiData = get(record, source);
-    if (!taiData) return <b>Conversion Error</b>;
-    const sn = taiData.split(':', 2);
-    const timestamp = new Date(1e3 * sn[0] + sn[1] / 1e6);
-    return dayjs(timestamp).format('YYYY-MM-DD HH:mm:ss.SSS');
-}
+const TAIConversion = (record, source, mode) => {
+    try {
+        const taiData = get(record, source).split(':', 2);
+        const taiTimeMilliseconds = 1e3 * taiData[0] + taiData[1] / 1e6;
+        if (get(record, mode) === 'activate_scheduled_relative') {
+            return dayjs(taiTimeMilliseconds)
+                .utc()
+                .format('HH:mm:ss.SSS');
+        }
+        const unixTimeMilliseconds = tai.atomicToUnix(taiTimeMilliseconds);
+        return dayjs(unixTimeMilliseconds).format('YYYY-MM-DD HH:mm:ss.SSS Z');
+    } catch (e) {
+        return `Conversion Error - ${e}`;
+    }
+};
 
 TAIField.defaultProps = {
     addLabel: true,

--- a/Development/src/pages/receivers.js
+++ b/Development/src/pages/receivers.js
@@ -386,6 +386,7 @@ const ShowActiveTab = ({ controllerProps, ...props }) => {
                 <TAIField
                     label="Requested Time"
                     source="$active.activation.requested_time"
+                    mode="$active.activation.mode"
                 />
                 <TAIField
                     label="Activation Time"
@@ -426,6 +427,7 @@ const ShowStagedTab = ({ controllerProps, ...props }) => {
                 <TAIField
                     label="Requested Time"
                     source="$staged.activation.requested_time"
+                    mode="$staged.activation.mode"
                 />
                 <TAIField
                     label="Activation Time"

--- a/Development/src/pages/senders.js
+++ b/Development/src/pages/senders.js
@@ -388,6 +388,7 @@ const ShowActiveTab = ({ controllerProps, ...props }) => {
                 <TAIField
                     label="Requested Time"
                     source="$active.activation.requested_time"
+                    mode="$active.activation.mode"
                 />
                 <TAIField
                     label="Activation Time"
@@ -427,6 +428,7 @@ const ShowStagedTab = ({ controllerProps, ...props }) => {
                 <TAIField
                     label="Requested Time"
                     source="$staged.activation.requested_time"
+                    mode="$staged.activation.mode"
                 />
                 <TAIField
                     label="Activation Time"

--- a/Development/yarn.lock
+++ b/Development/yarn.lock
@@ -2705,10 +2705,10 @@ date-now@^0.1.4:
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
   integrity sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=
 
-dayjs@^1.8.14:
-  version "1.8.15"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.15.tgz#7121bc04e6a7f2621ed6db566be4a8aaf8c3913e"
-  integrity sha512-HYHCI1nohG52B45vCQg8Re3hNDZbMroWPkhz50yaX7Lu0ATyjGsTdoYZBpjED9ar6chqTx2dmSmM8A51mojnAg==
+dayjs@^1.8.16:
+  version "1.8.16"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.16.tgz#2a3771de537255191b947957af2fd90012e71e64"
+  integrity sha512-XPmqzWz/EJiaRHjBqSJ2s6hE/BUoCIHKgdS2QPtTQtKcS9E4/Qn0WomoH1lXanWCzri+g7zPcuNV4aTZ8PMORQ==
 
 debounce@^1.1.0, debounce@^1.2.0:
   version "1.2.0"
@@ -9498,6 +9498,11 @@ symbol-tree@^3.2.1:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
+t-a-i@^1.0.15:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/t-a-i/-/t-a-i-1.0.15.tgz#d6f82343c572e59c06e6096f5ec2053afa2ae130"
+  integrity sha1-1vgjQ8Vy5ZwG5glvXsIFOvoq4TA=
 
 table@^4.0.1:
   version "4.0.3"


### PR DESCRIPTION
- Previously times were formatted and show as if they were UTC times.
  Currently TAI is exactly 37 seconds ahead of UTC. The new display
  accounts for leap seconds.
- Relative times are formatted as hh:mm:ss.sss