### PR TITLE
Add connect tab to receiver show view

### DIFF
--- a/Development/src/components/MakeConnection.js
+++ b/Development/src/components/MakeConnection.js
@@ -1,0 +1,217 @@
+import setJSON from 'json-ptr';
+import cloneDeep from 'lodash/cloneDeep';
+import get from 'lodash/get';
+import set from 'lodash/set';
+
+const oneToOneTransportParams = {
+    'urn:x-nmos:transport:mqtt': [
+        'broker_protocol',
+        'broker_authorization',
+        'broker_topic',
+        'connection_status_broker_topic',
+    ],
+    'urn:x-nmos:transport:rtp': [
+        'rtp_enabled',
+        'source_ip',
+        'destination_port',
+        'fec_enabled',
+        'fec_destination_ip',
+        'fec_mode',
+        'fec1D_destination_port',
+        'fec2D_destination_port',
+        'rtcp_enabled',
+        'rtcp_destination_ip',
+        'rtcp_destination_port',
+    ],
+    'urn:x-nmos:transport:websocket': [
+        'connection_authorization',
+        'connection_uri',
+    ],
+};
+
+const getExtParams = transport_params => {
+    const uniqueKeys = Object.keys(
+        transport_params.reduce(function(result, obj) {
+            return Object.assign(result, obj);
+        }, {})
+    );
+    return uniqueKeys.filter(function(x) {
+        return x.startsWith('ext_');
+    });
+};
+
+const copyTransportParams = (
+    senderTransportParams,
+    senderToReceiver,
+    patchData
+) => {
+    senderTransportParams.forEach(function(leg, index) {
+        senderToReceiver.forEach(function(param) {
+            const lhs = get(leg, param);
+            if (lhs !== undefined) {
+                setJSON.set(
+                    patchData,
+                    `/$staged/transport_params/${index}/${param}`,
+                    lhs,
+                    true
+                );
+            }
+        });
+    });
+};
+
+export const isMulticast = address => {
+    if (
+        address.match(
+            /^2(?:2[4-9]|3\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d?|0)){3}/
+        )
+    ) {
+        return true;
+    } else if (address.toLowerCase().startsWith('ff')) {
+        return true;
+    }
+    return false;
+};
+
+const MakeConnection = (senderID, receiverID, endpoint, props) => {
+    const { dataProvider } = props;
+    return new Promise((resolve, reject) => {
+        if (endpoint !== 'active' && endpoint !== 'staged') {
+            reject();
+        }
+
+        const senderPromise = new Promise(resolve =>
+            dataProvider('GET_ONE', 'senders', {
+                id: senderID,
+            }).then(response =>
+                resolve({ resource: 'sender', data: response.data })
+            )
+        );
+        const receiverPromise = new Promise(resolve =>
+            dataProvider('GET_ONE', 'receivers', {
+                id: receiverID,
+            }).then(response =>
+                resolve({ resource: 'receiver', data: response.data })
+            )
+        );
+
+        Promise.all([senderPromise, receiverPromise])
+            .then(response => {
+                let data = {};
+                for (const i of response) {
+                    data[i.resource] = i.data;
+                }
+                return data;
+            })
+            .then(data => {
+                if (get(data, 'sender') === undefined) reject();
+                if (get(data, 'receiver') === undefined) reject();
+                if (
+                    get(data.sender, '$transporttype') !==
+                    get(data.receiver, '$transporttype')
+                )
+                    reject();
+                let patchData = cloneDeep(data.receiver);
+
+                set(patchData, '$staged.master_enable', true);
+                set(patchData, '$staged.sender_id', get(data.sender, 'id'));
+                if (endpoint === 'active') {
+                    set(
+                        patchData,
+                        '$staged.activation.mode',
+                        'activate_immediate'
+                    );
+                }
+
+                const senderTransportParams = get(
+                    data.sender,
+                    '$active.transport_params'
+                );
+                if (!Array.isArray(senderTransportParams)) return;
+
+                copyTransportParams(
+                    senderTransportParams,
+                    oneToOneTransportParams[get(data.sender, '$transporttype')],
+                    patchData
+                );
+
+                switch (get(data.sender, '$transporttype')) {
+                    case 'urn:x-nmos:transport:mqtt':
+                        copyTransportParams(
+                            senderTransportParams,
+                            getExtParams(
+                                get(data.sender, '$active.transport_params')
+                            ),
+                            patchData
+                        );
+                        senderTransportParams.forEach(function(leg, index) {
+                            const destination_host = get(
+                                leg,
+                                'destination_host'
+                            );
+                            setJSON.set(
+                                patchData,
+                                `/$staged/transport_params/${index}/source_host`,
+                                destination_host,
+                                true
+                            );
+                            const destination_port = get(
+                                leg,
+                                'destination_port'
+                            );
+                            setJSON.set(
+                                patchData,
+                                `/$staged/transport_params/${index}/source_port`,
+                                destination_port,
+                                true
+                            );
+                        });
+                        break;
+                    case 'urn:x-nmos:transport:rtp':
+                        senderTransportParams.forEach(function(leg, index) {
+                            const destination_ip = get(leg, 'destination_ip');
+                            if (isMulticast(destination_ip)) {
+                                setJSON.set(
+                                    patchData,
+                                    `/$staged/transport_params/${index}/multicast_ip`,
+                                    destination_ip,
+                                    true
+                                );
+                            } else {
+                                setJSON.set(
+                                    patchData,
+                                    `/$staged/transport_params/${index}/interface_ip`,
+                                    destination_ip,
+                                    true
+                                );
+                            }
+                        });
+                        break;
+                    case 'urn:x-nmos:transport:websocket':
+                        copyTransportParams(
+                            senderTransportParams,
+                            getExtParams(
+                                get(data.sender, '$active.transport_params')
+                            ),
+                            patchData
+                        );
+                        break;
+                    default:
+                }
+                return {
+                    id: get(data.receiver, 'id'),
+                    data: patchData,
+                    previousData: data.receiver,
+                };
+            })
+            .then(params =>
+                dataProvider('UPDATE', 'receivers', params, {
+                    onSuccess: { refresh: true },
+                })
+            )
+            .then(() => resolve())
+            .catch(error => reject(error.message));
+    });
+};
+
+export default MakeConnection;

--- a/Development/src/components/MakeConnection.js
+++ b/Development/src/components/MakeConnection.js
@@ -61,16 +61,11 @@ const copyTransportParams = (
 };
 
 export const isMulticast = address => {
-    if (
+    return (
         address.match(
             /^2(?:2[4-9]|3\d)(?:\.(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]\d?|0)){3}/
-        )
-    ) {
-        return true;
-    } else if (address.toLowerCase().startsWith('ff')) {
-        return true;
-    }
-    return false;
+        ) || address.toLowerCase().startsWith('ff')
+    );
 };
 
 const MakeConnection = (senderID, receiverID, endpoint, props) => {
@@ -109,8 +104,10 @@ const MakeConnection = (senderID, receiverID, endpoint, props) => {
                 if (
                     get(data.sender, '$transporttype') !==
                     get(data.receiver, '$transporttype')
-                )
+                ) {
                     reject();
+                }
+
                 let patchData = cloneDeep(data.receiver);
 
                 set(patchData, '$staged.master_enable', true);

--- a/Development/src/pages/receivers.js
+++ b/Development/src/pages/receivers.js
@@ -38,6 +38,8 @@ import {
     TableRow,
     Tabs,
 } from '@material-ui/core';
+import CheckIcon from '@material-ui/icons/Check';
+import ClearIcon from '@material-ui/icons/Clear';
 import dataProvider from '../dataProvider';
 import PaginationButton from '../components/PaginationButton';
 import FilterField from '../components/FilterField';
@@ -132,6 +134,9 @@ export const ReceiversList = () => {
                                         setFilter={changeFilter}
                                     />
                                 </TableCell>
+                                {QueryVersion() >= 'v1.2' && (
+                                    <TableCell>Subscription Active</TableCell>
+                                )}
                             </TableRow>
                         </TableHead>
                         <TableBody>
@@ -149,6 +154,15 @@ export const ReceiversList = () => {
                                     </TableCell>
                                     <TableCell>{item.format}</TableCell>
                                     <TableCell>{item.transport}</TableCell>
+                                    {QueryVersion() >= 'v1.2' && (
+                                        <TableCell>
+                                            {item.subscription.active ? (
+                                                <CheckIcon />
+                                            ) : (
+                                                <ClearIcon />
+                                            )}
+                                        </TableCell>
+                                    )}
                                 </TableRow>
                             ))}
                         </TableBody>

--- a/Development/src/pages/receivers.js
+++ b/Development/src/pages/receivers.js
@@ -255,6 +255,9 @@ const ReceiversShowComponent = props => {
                                 value={`${props.match.url}/connect`}
                                 component={Link}
                                 to={`${props.basePath}/${props.id}/show/connect`}
+                                disabled={
+                                    !get(controllerProps.record, '$active')
+                                }
                             />
                         </Tabs>
                     </AppBar>

--- a/Development/src/pages/receivers.js
+++ b/Development/src/pages/receivers.js
@@ -1,5 +1,4 @@
-import set from 'lodash/set';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, Route } from 'react-router-dom';
 import {
     ArrayField,
@@ -23,8 +22,10 @@ import {
     TextInput,
     Title,
     Toolbar,
+    withDataProvider,
 } from 'react-admin';
 import get from 'lodash/get';
+import set from 'lodash/set';
 import Cookies from 'universal-cookie';
 import {
     AppBar,
@@ -34,6 +35,7 @@ import {
     Table,
     TableBody,
     TableCell,
+    TableFooter,
     TableHead,
     TableRow,
     Tabs,
@@ -52,6 +54,7 @@ import ConnectionEditActions from '../components/ConnectionEditActions';
 import JSONViewer from '../components/JSONViewer';
 import TransportFileViewer from '../components/TransportFileViewer';
 import ItemArrayField from '../components/ItemArrayField';
+import MakeConnection from '../components/MakeConnection';
 
 const cookies = new Cookies();
 
@@ -213,7 +216,7 @@ const QueryVersion = () => {
     return url.match(/([^/]+)(?=\/?$)/g)[0];
 };
 
-export const ReceiversShow = props => {
+const ReceiversShowComponent = props => {
     return (
         <ShowController {...props}>
             {controllerProps => (
@@ -247,6 +250,12 @@ export const ReceiversShow = props => {
                                         }
                                     />
                                 ))}
+                            <Tab
+                                label="Connect"
+                                value={`${props.match.url}/connect`}
+                                component={Link}
+                                to={`${props.basePath}/${props.id}/show/connect`}
+                            />
                         </Tabs>
                     </AppBar>
                     <Route
@@ -276,6 +285,17 @@ export const ReceiversShow = props => {
                             <ShowStagedTab
                                 {...props}
                                 controllerProps={controllerProps}
+                            />
+                        )}
+                    />
+                    <Route
+                        exact
+                        path={`${props.basePath}/${props.id}/show/connect`}
+                        render={() => (
+                            <ConnectionManagementTab
+                                {...props}
+                                controllerProps={controllerProps}
+                                receiverData={controllerProps.record}
                             />
                         )}
                     />
@@ -558,3 +578,199 @@ const EditStagedTab = props => (
         </SimpleForm>
     </Edit>
 );
+
+const ConnectionManagementTab = ({
+    controllerProps,
+    receiverData,
+    ...props
+}) => {
+    const [sendersListData, setSendersListData] = useState(undefined);
+    const [params, setParams] = useState({
+        filter: {},
+    });
+
+    useEffect(() => {
+        (async function fetchData() {
+            const data = await dataProvider('GET_LIST', 'senders', params);
+            setSendersListData(data);
+        })();
+    }, [params]);
+
+    const changeFilter = (filterValue, name) => {
+        let newFilter = params.filter;
+        if (filterValue) {
+            newFilter[name] = filterValue;
+        } else {
+            delete newFilter[name];
+        }
+        setParams({ filter: newFilter });
+    };
+
+    const nextPage = async label => {
+        const data = await dataProvider(label, 'senders');
+        setSendersListData(data);
+    };
+
+    // receiverData initialises undefined, update when no longer null
+    useEffect(() => {
+        if (receiverData !== null)
+            setParams({
+                filter: { transport: get(receiverData, 'transport') },
+            });
+    }, [receiverData]);
+
+    const connect = (senderID, receiverID, endpoint) => {
+        MakeConnection(senderID, receiverID, endpoint, props).then(() =>
+            props.history.push(`${props.basePath}/${props.id}/show/${endpoint}`)
+        );
+    };
+
+    return (
+        <ShowView
+            {...props}
+            {...controllerProps}
+            title={<ReceiversTitle />}
+            actions={<div />}
+        >
+            <SimpleShowLayout>
+                <Table>
+                    <TableHead>
+                        <TableRow>
+                            <TableCell
+                                style={{
+                                    minWidth: '240px',
+                                    paddingLeft: '32px',
+                                }}
+                            >
+                                Label{' '}
+                                <FilterField
+                                    name="label"
+                                    setFilter={changeFilter}
+                                />
+                            </TableCell>
+                            <TableCell>
+                                ID{' '}
+                                <FilterField
+                                    name="id"
+                                    setFilter={changeFilter}
+                                />
+                            </TableCell>
+                            <TableCell>Flow</TableCell>
+                            <TableCell>Device</TableCell>
+                            {QueryVersion() >= 'v1.2' && (
+                                <TableCell>Subscription Active</TableCell>
+                            )}
+                            <TableCell>Connect</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    {sendersListData && (
+                        <TableBody>
+                            {sendersListData.data.map(item => (
+                                <TableRow
+                                    key={item.id}
+                                    selected={
+                                        get(receiverData, 'id') === item.id
+                                    }
+                                >
+                                    <TableCell component="th" scope="row">
+                                        <ShowButton
+                                            style={{
+                                                textTransform: 'none',
+                                            }}
+                                            basePath="/senders"
+                                            record={item}
+                                            label={item.label}
+                                        />
+                                    </TableCell>
+                                    <TableCell>{item.id}</TableCell>
+                                    <TableCell>
+                                        <ReferenceField
+                                            record={item}
+                                            basePath="/flows"
+                                            label="Flow"
+                                            source="flow_id"
+                                            reference="flows"
+                                            linkType="show"
+                                        >
+                                            <ChipConditionalLabel source="label" />
+                                        </ReferenceField>
+                                    </TableCell>
+                                    <TableCell>
+                                        <ReferenceField
+                                            record={item}
+                                            basePath="/devices"
+                                            label="Device"
+                                            source="device_id"
+                                            reference="devices"
+                                            linkType="show"
+                                        >
+                                            <ChipConditionalLabel source="label" />
+                                        </ReferenceField>
+                                    </TableCell>
+                                    {QueryVersion() >= 'v1.2' && (
+                                        <TableCell>
+                                            {item.subscription.active ? (
+                                                <CheckIcon />
+                                            ) : (
+                                                <ClearIcon />
+                                            )}
+                                        </TableCell>
+                                    )}
+                                    <TableCell>
+                                        <Button
+                                            onClick={() =>
+                                                connect(
+                                                    item.id,
+                                                    get(receiverData, 'id'),
+                                                    'active'
+                                                )
+                                            }
+                                            label="Activate"
+                                        />
+                                        <Button
+                                            onClick={() =>
+                                                connect(
+                                                    item.id,
+                                                    get(receiverData, 'id'),
+                                                    'staged'
+                                                )
+                                            }
+                                            label="Stage"
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    )}
+                </Table>
+                <Table>
+                    <TableFooter>
+                        <TableRow>
+                            <TableCell style={{ whiteSpace: 'nowrap' }}>
+                                <PaginationButton
+                                    label="FIRST"
+                                    nextPage={nextPage}
+                                />
+                                <PaginationButton
+                                    label="PREV"
+                                    nextPage={nextPage}
+                                />
+                                <PaginationButton
+                                    label="NEXT"
+                                    nextPage={nextPage}
+                                />
+                                <PaginationButton
+                                    label="LAST"
+                                    nextPage={nextPage}
+                                />
+                            </TableCell>
+                        </TableRow>
+                    </TableFooter>
+                </Table>
+            </SimpleShowLayout>
+        </ShowView>
+    );
+};
+
+const ReceiversShow = withDataProvider(ReceiversShowComponent);
+export { ReceiversShow };

--- a/Development/src/pages/senders.js
+++ b/Development/src/pages/senders.js
@@ -41,6 +41,8 @@ import {
     Tabs,
     Typography,
 } from '@material-ui/core';
+import CheckIcon from '@material-ui/icons/Check';
+import ClearIcon from '@material-ui/icons/Clear';
 import dataProvider from '../dataProvider';
 import PaginationButton from '../components/PaginationButton';
 import FilterField from '../components/FilterField';
@@ -128,6 +130,9 @@ export const SendersList = () => {
                                         setFilter={changeFilter}
                                     />
                                 </TableCell>
+                                {QueryVersion() >= 'v1.2' && (
+                                    <TableCell>Subscription Active</TableCell>
+                                )}
                             </TableRow>
                         </TableHead>
                         <TableBody>
@@ -144,6 +149,15 @@ export const SendersList = () => {
                                         />
                                     </TableCell>
                                     <TableCell>{item.transport}</TableCell>
+                                    {QueryVersion() >= 'v1.2' && (
+                                        <TableCell>
+                                            {item.subscription.active ? (
+                                                <CheckIcon />
+                                            ) : (
+                                                <ClearIcon />
+                                            )}
+                                        </TableCell>
+                                    )}
                                 </TableRow>
                             ))}
                         </TableBody>


### PR DESCRIPTION
- A new tab has been added in the receiver show view with a list of
  compatible senders based on transport type.
- A connect button auto populates and sends an activation request to the
  receiver staged endpoint with the transport params of the chosen
  sender.
- Show the subscription_active field on both receiver and sender list
  views for query api versions >= v1.2