### PR TITLE
Fix console spam and reformat QueryAPI pages

### DIFF
--- a/Development/src/components/ActiveField.js
+++ b/Development/src/components/ActiveField.js
@@ -2,30 +2,8 @@ import React, { useEffect } from 'react';
 import { Switch } from '@material-ui/core';
 import { useNotify } from 'react-admin';
 import get from 'lodash/get';
-import omit from 'lodash/omit';
 import dataProvider from '../dataProvider';
-
-const sanitizeRestProps = props =>
-    omit(props, [
-        'addLabel',
-        'allowEmpty',
-        'basePath',
-        'cellClassName',
-        'className',
-        'formClassName',
-        'headerClassName',
-        'label',
-        'linkType',
-        'link',
-        'locale',
-        'record',
-        'resource',
-        'sortable',
-        'sortBy',
-        'source',
-        'textAlign',
-        'translateChoice',
-    ]);
+import sanitizeRestProps from './sanitizeRestProps';
 
 const toggleMasterEnable = (record, resource) => {
     return new Promise((resolve, reject) =>

--- a/Development/src/components/ConnectButton.js
+++ b/Development/src/components/ConnectButton.js
@@ -80,6 +80,7 @@ const ConnectButton = ({ record }) => {
                     <MenuItem
                         key={option}
                         onClick={() => handleMenuItemClick(option)}
+                        style={{ fontSize: '0.875rem' }}
                     >
                         {makeQueryAPIAddress(option)}
                     </MenuItem>

--- a/Development/src/components/sanitizeRestProps.js
+++ b/Development/src/components/sanitizeRestProps.js
@@ -1,0 +1,25 @@
+import omit from 'lodash/omit';
+
+const sanitizeRestProps = props =>
+    omit(props, [
+        'addLabel',
+        'allowEmpty',
+        'basePath',
+        'cellClassName',
+        'className',
+        'formClassName',
+        'headerClassName',
+        'label',
+        'linkType',
+        'link',
+        'locale',
+        'record',
+        'resource',
+        'sortable',
+        'sortBy',
+        'source',
+        'textAlign',
+        'translateChoice',
+    ]);
+
+export default sanitizeRestProps;

--- a/Development/src/pages/queryapis/QueryAPIsList.js
+++ b/Development/src/pages/queryapis/QueryAPIsList.js
@@ -49,8 +49,7 @@ const QueryAPIsList = props => {
                 {...props}
             >
                 <Datagrid>
-                    <ShowField label="Label" />
-                    <TextField source="port" sortable={false} />
+                    <ShowField label="Name" />
                     <TextField
                         label="API Versions"
                         source="txt.api_ver"

--- a/Development/src/pages/queryapis/QueryAPIsList.js
+++ b/Development/src/pages/queryapis/QueryAPIsList.js
@@ -1,29 +1,71 @@
 import React, { Fragment } from 'react';
+import { makeStyles } from '@material-ui/core';
 import { Datagrid, List, ShowButton, TextField } from 'react-admin';
+import get from 'lodash/get';
+import Cookies from 'universal-cookie';
 import ConnectButton from '../../components/ConnectButton';
+import ListActions from '../../components/ListActions';
 
-const QueryAPIsList = props => (
-    <List
-        title="Query APIs"
-        bulkActionButtons={false}
-        exporter={false}
-        pagination={<Fragment />}
-        {...props}
-    >
-        <Datagrid>
-            <ShowButton label="" />
+const cookies = new Cookies();
 
-            <TextField source="name" sortable={false} />
-            <TextField source="port" sortable={false} />
-            <TextField
-                label="API Versions"
-                source="txt.api_ver"
-                sortable={false}
-            />
-            <TextField label="Priority" source="txt.pri" sortable={false} />
-            <ConnectButton />
-        </Datagrid>
-    </List>
+const ShowField = ({ record = {}, basePath }) => (
+    <ShowButton
+        style={{
+            textTransform: 'none',
+        }}
+        basePath={basePath}
+        record={record}
+        label={get(record, 'name')}
+    />
 );
+
+const useStyles = makeStyles(theme => ({
+    content: {
+        padding: '16px',
+        marginTop: 0,
+        transition: theme.transitions.create('margin-top'),
+        position: 'relative',
+        flex: '1 1 auto',
+        [theme.breakpoints.down('xs')]: {
+            boxShadow: 'none',
+        },
+    },
+}));
+
+const QueryAPIsList = props => {
+    const classes = useStyles();
+    return (
+        <Fragment>
+            <List
+                actions={
+                    <ListActions
+                        url={cookies.get('DNS-SD API') + '/_nmos-query._tcp'}
+                    />
+                }
+                bulkActionButtons={false}
+                classes={classes}
+                title="Query APIs"
+                pagination={<Fragment />}
+                {...props}
+            >
+                <Datagrid>
+                    <ShowField label="Label" />
+                    <TextField source="port" sortable={false} />
+                    <TextField
+                        label="API Versions"
+                        source="txt.api_ver"
+                        sortable={false}
+                    />
+                    <TextField
+                        label="Priority"
+                        source="txt.pri"
+                        sortable={false}
+                    />
+                    <ConnectButton />
+                </Datagrid>
+            </List>
+        </Fragment>
+    );
+};
 
 export default QueryAPIsList;

--- a/Development/src/pages/queryapis/QueryAPIsShow.js
+++ b/Development/src/pages/queryapis/QueryAPIsShow.js
@@ -1,44 +1,86 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import {
+    Button,
     ListButton,
-    RichTextField,
-    Show,
+    ShowView,
     SimpleShowLayout,
     TextField,
+    Toolbar,
     TopToolbar,
+    useShowController,
 } from 'react-admin';
+import { makeStyles } from '@material-ui/core';
+import Cookies from 'universal-cookie';
 import ConnectButton from '../../components/ConnectButton';
+import ItemArrayField from '../../components/ItemArrayField';
+import JsonIcon from '../../icons/JsonIcon';
+
+const cookies = new Cookies();
 
 const QueryAPIsTitle = ({ record }) => {
     return <span>Query API{record ? `: ${record.name}` : ''}</span>;
 };
 
-const QueryAPIsShowActions = ({ basePath }) => (
+const QueryAPIsShowActions = ({ basePath, data }) => (
     <TopToolbar title={<QueryAPIsTitle />}>
+        {data ? (
+            <Button
+                label={'Raw'}
+                onClick={() =>
+                    window.open(
+                        cookies.get('DNS-SD API') +
+                            '/_nmos-query._tcp/' +
+                            data.id,
+                        '_blank'
+                    )
+                }
+                rel="noopener noreferrer"
+                title={'View raw'}
+            >
+                <JsonIcon />
+            </Button>
+        ) : null}
         <ListButton title={'Return to ' + basePath} basePath={basePath} />
     </TopToolbar>
 );
 
-const QueryAPIsShow = props => (
-    <Show
-        title={<QueryAPIsTitle />}
-        actions={<QueryAPIsShowActions />}
-        {...props}
-    >
-        <SimpleShowLayout>
-            <br />
-            <ConnectButton />
-            <TextField source="name" />
-            <hr />
-            <RichTextField source="addresses" />
-            <TextField label="Host Target" source="host_target" />
-            <TextField source="port" />
-            <hr />
-            <TextField label="API Protocol" source="txt.api_proto" />
-            <TextField label="API Versions" source="txt.api_ver" />
-            <TextField label="Priority" source="txt.pri" />
-        </SimpleShowLayout>
-    </Show>
-);
+const useStyles = makeStyles({
+    toolbar: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        marginTop: '0px',
+    },
+});
+
+const QueryAPIsShow = props => {
+    const controllerProps = useShowController(props);
+    return (
+        <ShowView
+            title={<QueryAPIsTitle />}
+            actions={<QueryAPIsShowActions />}
+            {...controllerProps}
+            {...props}
+        >
+            <Fragment>
+                <SimpleShowLayout {...props} {...controllerProps}>
+                    <TextField source="name" />
+                    <div />
+                    <ItemArrayField source="addresses" />
+                    <TextField label="Host Target" source="host_target" />
+                    <TextField source="port" />
+                    <div />
+                    <TextField label="API Protocol" source="txt.api_proto" />
+                    <TextField label="API Versions" source="txt.api_ver" />
+                    <TextField label="Priority" source="txt.pri" />
+                </SimpleShowLayout>
+                <Toolbar classes={useStyles()}>
+                    <Fragment>
+                        <ConnectButton record={controllerProps.record} />
+                    </Fragment>
+                </Toolbar>
+            </Fragment>
+        </ShowView>
+    );
+};
 
 export default QueryAPIsShow;

--- a/Development/src/pages/queryapis/QueryAPIsShow.js
+++ b/Development/src/pages/queryapis/QueryAPIsShow.js
@@ -64,11 +64,11 @@ const QueryAPIsShow = props => {
             <Fragment>
                 <SimpleShowLayout {...props} {...controllerProps}>
                     <TextField source="name" />
-                    <div />
-                    <ItemArrayField source="addresses" />
+                    <hr />
                     <TextField label="Host Target" source="host_target" />
+                    <ItemArrayField source="addresses" />
                     <TextField source="port" />
-                    <div />
+                    <hr />
                     <TextField label="API Protocol" source="txt.api_proto" />
                     <TextField label="API Versions" source="txt.api_ver" />
                     <TextField label="Priority" source="txt.pri" />

--- a/Development/src/pages/receivers/ReceiverTransportParams.js
+++ b/Development/src/pages/receivers/ReceiverTransportParams.js
@@ -14,95 +14,102 @@ import get from 'lodash/get';
 import { CardFormIterator } from '../../components/CardFormIterator';
 import CheckIcon from '@material-ui/icons/Check';
 import ClearIcon from '@material-ui/icons/Clear';
+import sanitizeRestProps from '../../components/sanitizeRestProps';
+
+// Passing react-admin props causes console spam
+const SanitizedDivider = ({ ...rest }) => (
+    <Divider {...sanitizeRestProps(rest)} />
+);
 
 const MQTTReceiver = ({ dataObject }) => {
     const params_ext = Object.keys(dataObject[0]).filter(function(x) {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <Grid container spacing={2}>
-                {Object.keys(dataObject).map(i => (
-                    <Grid item sm key={i}>
-                        <Card elevation={3}>
-                            <CardContent>
-                                <SimpleShowLayout record={dataObject[i]}>
-                                    {dataObject[i].hasOwnProperty(
-                                        'source_host'
-                                    ) && (
+        <Grid container spacing={2}>
+            {Object.keys(dataObject).map(i => (
+                <Grid item sm key={i}>
+                    <Card elevation={3}>
+                        <CardContent>
+                            <SimpleShowLayout record={dataObject[i]}>
+                                {dataObject[i].hasOwnProperty(
+                                    'source_host'
+                                ) && (
+                                    <TextField
+                                        source="source_host"
+                                        label="Source Host"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'source_port'
+                                ) && (
+                                    <TextField
+                                        source="source_port"
+                                        label="Source Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'broker_protocol'
+                                ) && (
+                                    <TextField
+                                        source="broker_protocol"
+                                        label="Broker Protocol"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'broker_authorization'
+                                ) && (
+                                    <SelectField
+                                        source="broker_authorization"
+                                        label="Broker Authorization"
+                                        choices={[
+                                            {
+                                                id: true,
+                                                name: <CheckIcon />,
+                                            },
+                                            {
+                                                id: false,
+                                                name: <ClearIcon />,
+                                            },
+                                            { id: 'auto', name: 'auto' },
+                                        ]}
+                                        translateChoice={false}
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'broker_topic'
+                                ) && (
+                                    <TextField
+                                        source="broker_topic"
+                                        label="Broker Topic"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'connection_status_broker_topic'
+                                ) && (
+                                    <TextField
+                                        source="connection_status_broker_topic"
+                                        label="Connection Status Broker Topic"
+                                    />
+                                )}
+                                {params_ext.length !== 0 && (
+                                    <SanitizedDivider />
+                                )}
+                                {params_ext.map(value => {
+                                    return (
                                         <TextField
-                                            source="source_host"
-                                            label="Source Host"
+                                            record={dataObject[i]}
+                                            source={value}
+                                            key={value}
                                         />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'source_port'
-                                    ) && (
-                                        <TextField
-                                            source="source_port"
-                                            label="Source Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'broker_protocol'
-                                    ) && (
-                                        <TextField
-                                            source="broker_protocol"
-                                            label="Broker Protocol"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'broker_authorization'
-                                    ) && (
-                                        <SelectField
-                                            source="broker_authorization"
-                                            label="Broker Authorization"
-                                            choices={[
-                                                {
-                                                    id: true,
-                                                    name: <CheckIcon />,
-                                                },
-                                                {
-                                                    id: false,
-                                                    name: <ClearIcon />,
-                                                },
-                                                { id: 'auto', name: 'auto' },
-                                            ]}
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'broker_topic'
-                                    ) && (
-                                        <TextField
-                                            source="broker_topic"
-                                            label="Broker Topic"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'connection_status_broker_topic'
-                                    ) && (
-                                        <TextField
-                                            source="connection_status_broker_topic"
-                                            label="Connection Status Broker Topic"
-                                        />
-                                    )}
-                                    {params_ext.length !== 0 && <Divider />}
-                                    {params_ext.map(value => {
-                                        return (
-                                            <TextField
-                                                record={dataObject[i]}
-                                                source={value}
-                                                key={value}
-                                            />
-                                        );
-                                    })}
-                                </SimpleShowLayout>
-                            </CardContent>
-                        </Card>
-                    </Grid>
-                ))}
-            </Grid>
-        </div>
+                                    );
+                                })}
+                            </SimpleShowLayout>
+                        </CardContent>
+                    </Card>
+                </Grid>
+            ))}
+        </Grid>
     );
 };
 
@@ -117,57 +124,52 @@ const MQTTReceiverEdit = ({ record }) => {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <ArrayInput
-                label="Transport Parameters"
-                source="$staged.transport_params"
-            >
-                <CardFormIterator disableRemove disableAdd>
-                    {uniqueKeys.includes('source_host') && (
-                        <TextInput source="source_host" label="Source Host" />
-                    )}
-                    {uniqueKeys.includes('source_port') && (
-                        <TextInput source="source_port" label="Source Port" />
-                    )}
-                    {uniqueKeys.includes('broker_protocol') && (
-                        <TextInput
-                            source="broker_protocol"
-                            label="Broker Protocol"
-                        />
-                    )}
-                    {uniqueKeys.includes('broker_authorization') && (
-                        <SelectInput
-                            source="broker_authorization"
-                            label="Broker Authorization"
-                            choices={[
-                                { id: true, name: <CheckIcon /> },
-                                { id: false, name: <ClearIcon /> },
-                                { id: 'auto', name: 'auto' },
-                            ]}
-                        />
-                    )}
-                    {uniqueKeys.includes('broker_topic') && (
-                        <TextInput source="broker_topic" label="Broker Topic" />
-                    )}
-                    {uniqueKeys.includes('connection_status_broker_topic') && (
-                        <TextInput
-                            source="connection_status_broker_topic"
-                            label="Connection Status Broker Topic"
-                        />
-                    )}
-                    {params_ext.length !== 0 && <Divider />}
-                    {params_ext.map(value => {
-                        return (
-                            <TextInput
-                                record={record}
-                                source={value}
-                                key={value}
-                            />
-                        );
-                    })}
-                </CardFormIterator>
-            </ArrayInput>
-        </div>
+        <ArrayInput
+            label="Transport Parameters"
+            source="$staged.transport_params"
+        >
+            <CardFormIterator disableRemove disableAdd>
+                {uniqueKeys.includes('source_host') && (
+                    <TextInput source="source_host" label="Source Host" />
+                )}
+                {uniqueKeys.includes('source_port') && (
+                    <TextInput source="source_port" label="Source Port" />
+                )}
+                {uniqueKeys.includes('broker_protocol') && (
+                    <TextInput
+                        source="broker_protocol"
+                        label="Broker Protocol"
+                    />
+                )}
+                {uniqueKeys.includes('broker_authorization') && (
+                    <SelectInput
+                        source="broker_authorization"
+                        label="Broker Authorization"
+                        choices={[
+                            { id: true, name: <CheckIcon /> },
+                            { id: false, name: <ClearIcon /> },
+                            { id: 'auto', name: 'auto' },
+                        ]}
+                        translateChoice={false}
+                    />
+                )}
+                {uniqueKeys.includes('broker_topic') && (
+                    <TextInput source="broker_topic" label="Broker Topic" />
+                )}
+                {uniqueKeys.includes('connection_status_broker_topic') && (
+                    <TextInput
+                        source="connection_status_broker_topic"
+                        label="Connection Status Broker Topic"
+                    />
+                )}
+                {params_ext.length !== 0 && <SanitizedDivider />}
+                {params_ext.map(value => {
+                    return (
+                        <TextInput record={record} source={value} key={value} />
+                    );
+                })}
+            </CardFormIterator>
+        </ArrayInput>
     );
 };
 
@@ -176,134 +178,130 @@ const RTPReceiver = ({ dataObject }) => {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <Grid container spacing={2}>
-                {Object.keys(dataObject).map(i => (
-                    <Grid item sm key={i}>
-                        <Card elevation={3}>
-                            <CardContent>
-                                <SimpleShowLayout record={dataObject[i]}>
-                                    {dataObject[i].hasOwnProperty(
-                                        'rtp_enabled'
-                                    ) && (
+        <Grid container spacing={2}>
+            {Object.keys(dataObject).map(i => (
+                <Grid item sm key={i}>
+                    <Card elevation={3}>
+                        <CardContent>
+                            <SimpleShowLayout record={dataObject[i]}>
+                                {dataObject[i].hasOwnProperty(
+                                    'rtp_enabled'
+                                ) && (
+                                    <BooleanField
+                                        source="rtp_enabled"
+                                        label="RTP Enabled"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty('source_ip') && (
+                                    <TextField
+                                        source="source_ip"
+                                        label="Source IP"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'multicast_ip'
+                                ) && (
+                                    <TextField
+                                        source="multicast_ip"
+                                        label="Multicast IP"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'interface_ip'
+                                ) && (
+                                    <TextField
+                                        source="interface_ip"
+                                        label="Interface IP"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'destination_port'
+                                ) && (
+                                    <TextField
+                                        source="destination_port"
+                                        label="Destination Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec_enabled'
+                                ) && <SanitizedDivider /> && (
                                         <BooleanField
-                                            source="rtp_enabled"
-                                            label="RTP Enabled"
+                                            source="fec_enabled"
+                                            label="FEC Enabled"
                                         />
                                     )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'source_ip'
-                                    ) && (
+                                {dataObject[i].hasOwnProperty('fec_mode') && (
+                                    <TextField
+                                        source="fec_mode"
+                                        label="FEC Mode"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec_destination_ip'
+                                ) && (
+                                    <TextField
+                                        source="fec_destination_ip"
+                                        label="FEC Destination IP"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec1D_destination_port'
+                                ) && (
+                                    <TextField
+                                        source="fec1D_destination_port"
+                                        label="FEC1D Destination Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec2D_destination_port'
+                                ) && (
+                                    <TextField
+                                        source="fec2D_destination_port"
+                                        label="FEC2D Destination Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'rtcp_enabled'
+                                ) && <SanitizedDivider /> && (
+                                        <BooleanField
+                                            source="rtcp_enabled"
+                                            label="RTCP Enabled"
+                                        />
+                                    )}
+                                {dataObject[i].hasOwnProperty(
+                                    'rtcp_destination_ip'
+                                ) && (
+                                    <TextField
+                                        source="rtcp_destination_ip"
+                                        label="RTCP Destination IP"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'rtcp_destination_port'
+                                ) && (
+                                    <TextField
+                                        source="rtcp_destination_port"
+                                        label="RTCP Destination Port"
+                                    />
+                                )}
+                                {params_ext.length !== 0 && (
+                                    <SanitizedDivider />
+                                )}
+                                {params_ext.map(value => {
+                                    return (
                                         <TextField
-                                            source="source_ip"
-                                            label="Source IP"
+                                            record={dataObject[i]}
+                                            source={value}
+                                            key={value}
                                         />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'multicast_ip'
-                                    ) && (
-                                        <TextField
-                                            source="multicast_ip"
-                                            label="Multicast IP"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'interface_ip'
-                                    ) && (
-                                        <TextField
-                                            source="interface_ip"
-                                            label="Interface IP"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'destination_port'
-                                    ) && (
-                                        <TextField
-                                            source="destination_port"
-                                            label="Destination Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec_enabled'
-                                    ) && <Divider /> && (
-                                            <BooleanField
-                                                source="fec_enabled"
-                                                label="FEC Enabled"
-                                            />
-                                        )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec_mode'
-                                    ) && (
-                                        <TextField
-                                            source="fec_mode"
-                                            label="FEC Mode"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec_destination_ip'
-                                    ) && (
-                                        <TextField
-                                            source="fec_destination_ip"
-                                            label="FEC Destination IP"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec1D_destination_port'
-                                    ) && (
-                                        <TextField
-                                            source="fec1D_destination_port"
-                                            label="FEC1D Destination Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec2D_destination_port'
-                                    ) && (
-                                        <TextField
-                                            source="fec2D_destination_port"
-                                            label="FEC2D Destination Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'rtcp_enabled'
-                                    ) && <Divider /> && (
-                                            <BooleanField
-                                                source="rtcp_enabled"
-                                                label="RTCP Enabled"
-                                            />
-                                        )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'rtcp_destination_ip'
-                                    ) && (
-                                        <TextField
-                                            source="rtcp_destination_ip"
-                                            label="RTCP Destination IP"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'rtcp_destination_port'
-                                    ) && (
-                                        <TextField
-                                            source="rtcp_destination_port"
-                                            label="RTCP Destination Port"
-                                        />
-                                    )}
-                                    {params_ext.length !== 0 && <Divider />}
-                                    {params_ext.map(value => {
-                                        return (
-                                            <TextField
-                                                record={dataObject[i]}
-                                                source={value}
-                                                key={value}
-                                            />
-                                        );
-                                    })}
-                                </SimpleShowLayout>
-                            </CardContent>
-                        </Card>
-                    </Grid>
-                ))}
-            </Grid>
-        </div>
+                                    );
+                                })}
+                            </SimpleShowLayout>
+                        </CardContent>
+                    </Card>
+                </Grid>
+            ))}
+        </Grid>
     );
 };
 
@@ -318,91 +316,76 @@ const RTPReceiverEdit = ({ record }) => {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <ArrayInput
-                label="Transport Parameters"
-                source="$staged.transport_params"
-            >
-                <CardFormIterator disableRemove disableAdd>
-                    {uniqueKeys.includes('rtp_enabled') && (
-                        <BooleanInput
-                            source="rtp_enabled"
-                            label="RTP Enabled"
-                        />
-                    )}
-                    {uniqueKeys.includes('source_ip') && (
-                        <TextInput source="source_ip" label="Source IP" />
-                    )}
-                    {uniqueKeys.includes('multicast_ip') && (
-                        <TextInput source="multicast_ip" label="Multicast IP" />
-                    )}
-                    {uniqueKeys.includes('interface_ip') && (
-                        <TextInput source="interface_ip" label="Interface IP" />
-                    )}
-                    {uniqueKeys.includes('destination_port') && (
-                        <TextInput
-                            source="destination_port"
-                            label="Destination Port"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec_enabled') && (
-                        <BooleanInput
-                            source="fec_enabled"
-                            label="FEC Enabled"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec_mode') && (
-                        <TextInput source="fec_mode" label="FEC Mode" />
-                    )}
-                    {uniqueKeys.includes('fec_destination_ip') && (
-                        <TextInput
-                            source="fec_destination_ip"
-                            label="FEC Destination IP"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec1D_destination_port') && (
-                        <TextInput
-                            source="fec1D_destination_port"
-                            label="FEC1D Destination Port"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec2D_destination_port') && (
-                        <TextInput
-                            source="fec2D_destination_port"
-                            label="FEC2D Destination Port"
-                        />
-                    )}
-                    {uniqueKeys.includes('rtcp_enabled') && (
-                        <BooleanInput
-                            source="rtcp_enabled"
-                            label="RTCP Enabled"
-                        />
-                    )}
-                    {uniqueKeys.includes('rtcp_destination_ip') && (
-                        <TextInput
-                            source="rtcp_destination_ip"
-                            label="RTCP Destination IP"
-                        />
-                    )}
-                    {uniqueKeys.includes('rtcp_destination_port') && (
-                        <TextInput
-                            source="rtcp_destination_port"
-                            label="RTCP Destination Port"
-                        />
-                    )}
-                    {params_ext.length !== 0 && <Divider />}
-                    {params_ext.map(value => {
-                        return (
-                            <TextInput
-                                record={record}
-                                source={value}
-                                key={value}
-                            />
-                        );
-                    })}
-                </CardFormIterator>
-            </ArrayInput>
-        </div>
+        <ArrayInput
+            label="Transport Parameters"
+            source="$staged.transport_params"
+        >
+            <CardFormIterator disableRemove disableAdd>
+                {uniqueKeys.includes('rtp_enabled') && (
+                    <BooleanInput source="rtp_enabled" label="RTP Enabled" />
+                )}
+                {uniqueKeys.includes('source_ip') && (
+                    <TextInput source="source_ip" label="Source IP" />
+                )}
+                {uniqueKeys.includes('multicast_ip') && (
+                    <TextInput source="multicast_ip" label="Multicast IP" />
+                )}
+                {uniqueKeys.includes('interface_ip') && (
+                    <TextInput source="interface_ip" label="Interface IP" />
+                )}
+                {uniqueKeys.includes('destination_port') && (
+                    <TextInput
+                        source="destination_port"
+                        label="Destination Port"
+                    />
+                )}
+                {uniqueKeys.includes('fec_enabled') && (
+                    <BooleanInput source="fec_enabled" label="FEC Enabled" />
+                )}
+                {uniqueKeys.includes('fec_mode') && (
+                    <TextInput source="fec_mode" label="FEC Mode" />
+                )}
+                {uniqueKeys.includes('fec_destination_ip') && (
+                    <TextInput
+                        source="fec_destination_ip"
+                        label="FEC Destination IP"
+                    />
+                )}
+                {uniqueKeys.includes('fec1D_destination_port') && (
+                    <TextInput
+                        source="fec1D_destination_port"
+                        label="FEC1D Destination Port"
+                    />
+                )}
+                {uniqueKeys.includes('fec2D_destination_port') && (
+                    <TextInput
+                        source="fec2D_destination_port"
+                        label="FEC2D Destination Port"
+                    />
+                )}
+                {uniqueKeys.includes('rtcp_enabled') && (
+                    <BooleanInput source="rtcp_enabled" label="RTCP Enabled" />
+                )}
+                {uniqueKeys.includes('rtcp_destination_ip') && (
+                    <TextInput
+                        source="rtcp_destination_ip"
+                        label="RTCP Destination IP"
+                    />
+                )}
+                {uniqueKeys.includes('rtcp_destination_port') && (
+                    <TextInput
+                        source="rtcp_destination_port"
+                        label="RTCP Destination Port"
+                    />
+                )}
+                {params_ext.length !== 0 && <SanitizedDivider />}
+                {params_ext.map(value => {
+                    return (
+                        <TextInput record={record} source={value} key={value} />
+                    );
+                })}
+            </CardFormIterator>
+        </ArrayInput>
     );
 };
 
@@ -411,57 +394,58 @@ const WebSocketReceiver = ({ dataObject }) => {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <Grid container spacing={2}>
-                {Object.keys(dataObject).map(i => (
-                    <Grid item sm key={i}>
-                        <Card elevation={3}>
-                            <CardContent>
-                                <SimpleShowLayout record={dataObject[i]}>
-                                    {dataObject[i].hasOwnProperty(
-                                        'connection_authorization'
-                                    ) && (
-                                        <SelectField
-                                            source="connection_authorization"
-                                            label="Connection Authorization"
-                                            choices={[
-                                                {
-                                                    id: true,
-                                                    name: <CheckIcon />,
-                                                },
-                                                {
-                                                    id: false,
-                                                    name: <ClearIcon />,
-                                                },
-                                                { id: 'auto', name: 'auto' },
-                                            ]}
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'connection_uri'
-                                    ) && (
+        <Grid container spacing={2}>
+            {Object.keys(dataObject).map(i => (
+                <Grid item sm key={i}>
+                    <Card elevation={3}>
+                        <CardContent>
+                            <SimpleShowLayout record={dataObject[i]}>
+                                {dataObject[i].hasOwnProperty(
+                                    'connection_authorization'
+                                ) && (
+                                    <SelectField
+                                        source="connection_authorization"
+                                        label="Connection Authorization"
+                                        choices={[
+                                            {
+                                                id: true,
+                                                name: <CheckIcon />,
+                                            },
+                                            {
+                                                id: false,
+                                                name: <ClearIcon />,
+                                            },
+                                            { id: 'auto', name: 'auto' },
+                                        ]}
+                                        translateChoice={false}
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'connection_uri'
+                                ) && (
+                                    <TextField
+                                        source="connection_uri"
+                                        label="Connection URI"
+                                    />
+                                )}
+                                {params_ext.length !== 0 && (
+                                    <SanitizedDivider />
+                                )}
+                                {params_ext.map(value => {
+                                    return (
                                         <TextField
-                                            source="connection_uri"
-                                            label="Connection URI"
+                                            record={dataObject[i]}
+                                            source={value}
+                                            key={value}
                                         />
-                                    )}
-                                    {params_ext.length !== 0 && <Divider />}
-                                    {params_ext.map(value => {
-                                        return (
-                                            <TextField
-                                                record={dataObject[i]}
-                                                source={value}
-                                                key={value}
-                                            />
-                                        );
-                                    })}
-                                </SimpleShowLayout>
-                            </CardContent>
-                        </Card>
-                    </Grid>
-                ))}
-            </Grid>
-        </div>
+                                    );
+                                })}
+                            </SimpleShowLayout>
+                        </CardContent>
+                    </Card>
+                </Grid>
+            ))}
+        </Grid>
     );
 };
 
@@ -476,42 +460,34 @@ const WebSocketReceiverEdit = ({ record }) => {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <ArrayInput
-                label="Transport Parameters"
-                source="$staged.transport_params"
-            >
-                <CardFormIterator disableRemove disableAdd>
-                    {uniqueKeys.includes('connection_authorization') && (
-                        <SelectInput
-                            source="connection_authorization"
-                            label="Connection Authorization"
-                            choices={[
-                                { id: true, name: <CheckIcon /> },
-                                { id: false, name: <ClearIcon /> },
-                                { id: 'auto', name: 'auto' },
-                            ]}
-                        />
-                    )}
-                    {uniqueKeys.includes('connection_uri') && (
-                        <TextInput
-                            source="connection_uri"
-                            label="Connection URI"
-                        />
-                    )}
-                    {params_ext.length !== 0 && <Divider />}
-                    {params_ext.map(value => {
-                        return (
-                            <TextInput
-                                record={record}
-                                source={value}
-                                key={value}
-                            />
-                        );
-                    })}
-                </CardFormIterator>
-            </ArrayInput>
-        </div>
+        <ArrayInput
+            label="Transport Parameters"
+            source="$staged.transport_params"
+        >
+            <CardFormIterator disableRemove disableAdd>
+                {uniqueKeys.includes('connection_authorization') && (
+                    <SelectInput
+                        source="connection_authorization"
+                        label="Connection Authorization"
+                        choices={[
+                            { id: true, name: <CheckIcon /> },
+                            { id: false, name: <ClearIcon /> },
+                            { id: 'auto', name: 'auto' },
+                        ]}
+                        translateChoice={false}
+                    />
+                )}
+                {uniqueKeys.includes('connection_uri') && (
+                    <TextInput source="connection_uri" label="Connection URI" />
+                )}
+                {params_ext.length !== 0 && <SanitizedDivider />}
+                {params_ext.map(value => {
+                    return (
+                        <TextInput record={record} source={value} key={value} />
+                    );
+                })}
+            </CardFormIterator>
+        </ArrayInput>
     );
 };
 

--- a/Development/src/pages/receivers/ReceiversList.js
+++ b/Development/src/pages/receivers/ReceiversList.js
@@ -105,7 +105,6 @@ const ReceiversList = props => {
                                             <ActiveField
                                                 record={item}
                                                 resource="receivers"
-                                                refresh
                                             />
                                         </TableCell>
                                     )}

--- a/Development/src/pages/receivers/ReceiversShow.js
+++ b/Development/src/pages/receivers/ReceiversShow.js
@@ -350,7 +350,7 @@ const ConnectionManagementTab = ({
     const refreshWholeView = useRefresh();
     // we need to force update the sender data without refreshing
     // the whole view
-    const [refresh, setRefresh] = useState(0);
+    const [refresh, setRefresh] = useState(true);
     const [filter, setFilter] = useState({
         transport: get(receiverData, 'transport'),
     });

--- a/Development/src/pages/receivers/ReceiversShow.js
+++ b/Development/src/pages/receivers/ReceiversShow.js
@@ -350,7 +350,7 @@ const ConnectionManagementTab = ({
     const refreshWholeView = useRefresh();
     // we need to force update the sender data without refreshing
     // the whole view
-    const [refresh, setRefresh] = useState(true);
+    const [refresh, setRefresh] = useState(0);
     const [filter, setFilter] = useState({
         transport: get(receiverData, 'transport'),
     });
@@ -418,116 +418,123 @@ const ConnectionManagementTab = ({
             actions={<Fragment />}
         >
             <SimpleShowLayout>
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell
-                                style={{
-                                    paddingLeft: '32px',
-                                }}
-                            >
-                                Sender{' '}
-                                <FilterField
-                                    name="label"
-                                    setFilter={changeFilter}
-                                />
-                            </TableCell>
-                            <TableCell>Flow</TableCell>
-                            {QueryVersion() >= 'v1.2' && (
-                                <TableCell>Active</TableCell>
-                            )}
-                            <TableCell>Connect</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {data.map(item => (
-                            <TableRow
-                                key={item.id}
-                                selected={get(receiverData, 'id') === item.id}
-                            >
-                                <TableCell component="th" scope="row">
-                                    {
-                                        // Using linkToRecord as ReferenceField will
-                                        // make a new unnecessary network request
-                                    }
-                                    <Link
-                                        to={`${linkToRecord(
-                                            '/senders',
-                                            item.id
-                                        )}/show`}
-                                    >
-                                        <ChipConditionalLabel
-                                            record={item}
-                                            source="label"
-                                            label="ra.action.show"
-                                        />
-                                    </Link>
+                <Fragment>
+                    <Table>
+                        <TableHead>
+                            <TableRow>
+                                <TableCell
+                                    style={{
+                                        paddingLeft: '32px',
+                                    }}
+                                >
+                                    Sender{' '}
+                                    <FilterField
+                                        name="label"
+                                        setFilter={changeFilter}
+                                    />
                                 </TableCell>
-                                <TableCell>
-                                    <ReferenceField
-                                        record={item}
-                                        basePath="/flows"
-                                        label="Flow"
-                                        source="flow_id"
-                                        reference="flows"
-                                        link="show"
-                                    >
-                                        <ChipConditionalLabel source="label" />
-                                    </ReferenceField>
-                                </TableCell>
+                                <TableCell>Flow</TableCell>
                                 {QueryVersion() >= 'v1.2' && (
-                                    <TableCell>
-                                        <ActiveField
-                                            record={item}
-                                            resource="senders"
-                                        />
-                                    </TableCell>
+                                    <TableCell>Active</TableCell>
                                 )}
-                                <TableCell>
-                                    <Button
-                                        onClick={() =>
-                                            connect(
-                                                item.id,
-                                                get(receiverData, 'id'),
-                                                'active'
-                                            )
+                                <TableCell>Connect</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {data.map(item => (
+                                <TableRow
+                                    key={item.id}
+                                    selected={
+                                        get(receiverData, 'id') === item.id
+                                    }
+                                >
+                                    <TableCell component="th" scope="row">
+                                        {
+                                            // Using linkToRecord as ReferenceField will
+                                            // make a new unnecessary network request
                                         }
-                                        color="primary"
-                                        startIcon={<ActivateImmediateIcon />}
-                                    >
-                                        Activate
-                                    </Button>
-                                    <Button
-                                        onClick={() =>
-                                            connect(
-                                                item.id,
-                                                get(receiverData, 'id'),
-                                                'staged'
-                                            )
-                                        }
-                                        color="primary"
-                                        startIcon={<StageIcon />}
-                                    >
-                                        Stage
-                                    </Button>
+                                        <Link
+                                            to={`${linkToRecord(
+                                                '/senders',
+                                                item.id
+                                            )}/show`}
+                                        >
+                                            <ChipConditionalLabel
+                                                record={item}
+                                                source="label"
+                                                label="ra.action.show"
+                                            />
+                                        </Link>
+                                    </TableCell>
+                                    <TableCell>
+                                        <ReferenceField
+                                            record={item}
+                                            basePath="/flows"
+                                            label="Flow"
+                                            source="flow_id"
+                                            reference="flows"
+                                            link="show"
+                                        >
+                                            <ChipConditionalLabel source="label" />
+                                        </ReferenceField>
+                                    </TableCell>
+                                    {QueryVersion() >= 'v1.2' && (
+                                        <TableCell>
+                                            <ActiveField
+                                                record={item}
+                                                resource="senders"
+                                            />
+                                        </TableCell>
+                                    )}
+                                    <TableCell>
+                                        <Button
+                                            onClick={() =>
+                                                connect(
+                                                    item.id,
+                                                    get(receiverData, 'id'),
+                                                    'active'
+                                                )
+                                            }
+                                            color="primary"
+                                            startIcon={
+                                                <ActivateImmediateIcon />
+                                            }
+                                        >
+                                            Activate
+                                        </Button>
+                                        <Button
+                                            onClick={() =>
+                                                connect(
+                                                    item.id,
+                                                    get(receiverData, 'id'),
+                                                    'staged'
+                                                )
+                                            }
+                                            color="primary"
+                                            startIcon={<StageIcon />}
+                                        >
+                                            Stage
+                                        </Button>
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+
+                    <Table>
+                        <TableFooter>
+                            <TableRow>
+                                <TableCell style={{ whiteSpace: 'nowrap' }}>
+                                    <PaginationButtons
+                                        disabled={!pagination}
+                                        nextPage={nextPage}
+                                        {...props}
+                                    />
                                 </TableCell>
                             </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-                <Table>
-                    <TableFooter>
-                        <TableRow>
-                            <TableCell style={{ whiteSpace: 'nowrap' }}>
-                                <PaginationButtons
-                                    disabled={!pagination}
-                                    nextPage={nextPage}
-                                    {...props}
-                                />
-                            </TableCell>
-                        </TableRow>
-                    </TableFooter>
-                </Table>
+                        </TableFooter>
+                    </Table>
+                </Fragment>
             </SimpleShowLayout>
         </ShowView>
     );

--- a/Development/src/pages/senders/SenderTransportParams.js
+++ b/Development/src/pages/senders/SenderTransportParams.js
@@ -14,95 +14,102 @@ import get from 'lodash/get';
 import { CardFormIterator } from '../../components/CardFormIterator';
 import CheckIcon from '@material-ui/icons/Check';
 import ClearIcon from '@material-ui/icons/Clear';
+import sanitizeRestProps from '../../components/sanitizeRestProps';
+
+// Passing react-admin props causes console spam
+const SanitizedDivider = ({ ...rest }) => (
+    <Divider {...sanitizeRestProps(rest)} />
+);
 
 const MQTTSender = ({ dataObject }) => {
     const params_ext = Object.keys(dataObject[0]).filter(function(x) {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <Grid container spacing={2}>
-                {Object.keys(dataObject).map(i => (
-                    <Grid item sm key={i}>
-                        <Card elevation={3}>
-                            <CardContent>
-                                <SimpleShowLayout record={dataObject[i]}>
-                                    {dataObject[i].hasOwnProperty(
-                                        'destination_host'
-                                    ) && (
+        <Grid container spacing={2}>
+            {Object.keys(dataObject).map(i => (
+                <Grid item sm key={i}>
+                    <Card elevation={3}>
+                        <CardContent>
+                            <SimpleShowLayout record={dataObject[i]}>
+                                {dataObject[i].hasOwnProperty(
+                                    'destination_host'
+                                ) && (
+                                    <TextField
+                                        source="destination_host"
+                                        label="Destination Host"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'destination_port'
+                                ) && (
+                                    <TextField
+                                        source="destination_port"
+                                        label="Destination Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'broker_protocol'
+                                ) && (
+                                    <TextField
+                                        source="broker_protocol"
+                                        label="Broker Protocol"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'broker_authorization'
+                                ) && (
+                                    <SelectField
+                                        source="broker_authorization"
+                                        label="Broker Authorization"
+                                        choices={[
+                                            {
+                                                id: true,
+                                                name: <CheckIcon />,
+                                            },
+                                            {
+                                                id: false,
+                                                name: <ClearIcon />,
+                                            },
+                                            { id: 'auto', name: 'auto' },
+                                        ]}
+                                        translateChoice={false}
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'broker_topic'
+                                ) && (
+                                    <TextField
+                                        source="broker_topic"
+                                        label="Broker Topic"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'connection_status_broker_topic'
+                                ) && (
+                                    <TextField
+                                        source="connection_status_broker_topic"
+                                        label="Connection Status Broker Topic"
+                                    />
+                                )}
+                                {params_ext.length !== 0 && (
+                                    <SanitizedDivider />
+                                )}
+                                {params_ext.map(value => {
+                                    return (
                                         <TextField
-                                            source="destination_host"
-                                            label="Destination Host"
+                                            record={dataObject[i]}
+                                            source={value}
+                                            key={value}
                                         />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'destination_port'
-                                    ) && (
-                                        <TextField
-                                            source="destination_port"
-                                            label="Destination Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'broker_protocol'
-                                    ) && (
-                                        <TextField
-                                            source="broker_protocol"
-                                            label="Broker Protocol"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'broker_authorization'
-                                    ) && (
-                                        <SelectField
-                                            source="broker_authorization"
-                                            label="Broker Authorization"
-                                            choices={[
-                                                {
-                                                    id: true,
-                                                    name: <CheckIcon />,
-                                                },
-                                                {
-                                                    id: false,
-                                                    name: <ClearIcon />,
-                                                },
-                                                { id: 'auto', name: 'auto' },
-                                            ]}
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'broker_topic'
-                                    ) && (
-                                        <TextField
-                                            source="broker_topic"
-                                            label="Broker Topic"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'connection_status_broker_topic'
-                                    ) && (
-                                        <TextField
-                                            source="connection_status_broker_topic"
-                                            label="Connection Status Broker Topic"
-                                        />
-                                    )}
-                                    {params_ext.length !== 0 && <Divider />}
-                                    {params_ext.map(value => {
-                                        return (
-                                            <TextField
-                                                record={dataObject[i]}
-                                                source={value}
-                                                key={value}
-                                            />
-                                        );
-                                    })}
-                                </SimpleShowLayout>
-                            </CardContent>
-                        </Card>
-                    </Grid>
-                ))}
-            </Grid>
-        </div>
+                                    );
+                                })}
+                            </SimpleShowLayout>
+                        </CardContent>
+                    </Card>
+                </Grid>
+            ))}
+        </Grid>
     );
 };
 
@@ -117,63 +124,58 @@ const MQTTSenderEdit = ({ record }) => {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <ArrayInput
-                label="Transport Parameters"
-                source="$staged.transport_params"
-            >
-                <CardFormIterator disableRemove disableAdd>
-                    {uniqueKeys.includes('destination_host') && (
-                        <TextInput
-                            source="destination_host"
-                            label="Destination Host"
-                        />
-                    )}
-                    {uniqueKeys.includes('destination_port') && (
-                        <TextInput
-                            source="destination_port"
-                            label="Destination Port"
-                        />
-                    )}
-                    {uniqueKeys.includes('broker_protocol') && (
-                        <TextInput
-                            source="broker_protocol"
-                            label="Broker Protocol"
-                        />
-                    )}
-                    {uniqueKeys.includes('broker_authorization') && (
-                        <SelectInput
-                            source="broker_authorization"
-                            label="Broker Authorization"
-                            choices={[
-                                { id: true, name: <CheckIcon /> },
-                                { id: false, name: <ClearIcon /> },
-                                { id: 'auto', name: 'auto' },
-                            ]}
-                        />
-                    )}
-                    {uniqueKeys.includes('broker_topic') && (
-                        <TextInput source="broker_topic" label="Broker Topic" />
-                    )}
-                    {uniqueKeys.includes('connection_status_broker_topic') && (
-                        <TextInput
-                            source="connection_status_broker_topic"
-                            label="Connection Status Broker Topic"
-                        />
-                    )}
-                    {params_ext.length !== 0 && <Divider />}
-                    {params_ext.map(value => {
-                        return (
-                            <TextInput
-                                record={record}
-                                source={value}
-                                key={value}
-                            />
-                        );
-                    })}
-                </CardFormIterator>
-            </ArrayInput>
-        </div>
+        <ArrayInput
+            label="Transport Parameters"
+            source="$staged.transport_params"
+        >
+            <CardFormIterator disableRemove disableAdd>
+                {uniqueKeys.includes('destination_host') && (
+                    <TextInput
+                        source="destination_host"
+                        label="Destination Host"
+                    />
+                )}
+                {uniqueKeys.includes('destination_port') && (
+                    <TextInput
+                        source="destination_port"
+                        label="Destination Port"
+                    />
+                )}
+                {uniqueKeys.includes('broker_protocol') && (
+                    <TextInput
+                        source="broker_protocol"
+                        label="Broker Protocol"
+                    />
+                )}
+                {uniqueKeys.includes('broker_authorization') && (
+                    <SelectInput
+                        source="broker_authorization"
+                        label="Broker Authorization"
+                        choices={[
+                            { id: true, name: <CheckIcon /> },
+                            { id: false, name: <ClearIcon /> },
+                            { id: 'auto', name: 'auto' },
+                        ]}
+                        translateChoice={false}
+                    />
+                )}
+                {uniqueKeys.includes('broker_topic') && (
+                    <TextInput source="broker_topic" label="Broker Topic" />
+                )}
+                {uniqueKeys.includes('connection_status_broker_topic') && (
+                    <TextInput
+                        source="connection_status_broker_topic"
+                        label="Connection Status Broker Topic"
+                    />
+                )}
+                {params_ext.length !== 0 && <SanitizedDivider />}
+                {params_ext.map(value => {
+                    return (
+                        <TextInput record={record} source={value} key={value} />
+                    );
+                })}
+            </CardFormIterator>
+        </ArrayInput>
     );
 };
 
@@ -182,182 +184,176 @@ const RTPSender = ({ dataObject }) => {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <Grid container spacing={2}>
-                {Object.keys(dataObject).map(i => (
-                    <Grid item sm key={i}>
-                        <Card elevation={3}>
-                            <CardContent>
-                                <SimpleShowLayout record={dataObject[i]}>
-                                    {dataObject[i].hasOwnProperty(
-                                        'rtp_enabled'
-                                    ) && (
+        <Grid container spacing={2}>
+            {Object.keys(dataObject).map(i => (
+                <Grid item sm key={i}>
+                    <Card elevation={3}>
+                        <CardContent>
+                            <SimpleShowLayout record={dataObject[i]}>
+                                {dataObject[i].hasOwnProperty(
+                                    'rtp_enabled'
+                                ) && (
+                                    <BooleanField
+                                        source="rtp_enabled"
+                                        label="RTP Enabled"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty('source_ip') && (
+                                    <TextField
+                                        source="source_ip"
+                                        label="Source IP"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'destination_ip'
+                                ) && (
+                                    <TextField
+                                        source="destination_ip"
+                                        label="Destination IP"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'source_port'
+                                ) && (
+                                    <TextField
+                                        source="source_port"
+                                        label="Source Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'destination_port'
+                                ) && (
+                                    <TextField
+                                        source="destination_port"
+                                        label="Destination Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec_enabled'
+                                ) && <SanitizedDivider /> && (
                                         <BooleanField
-                                            source="rtp_enabled"
-                                            label="RTP Enabled"
+                                            source="fec_enabled"
+                                            label="FEC Enabled"
                                         />
                                     )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'source_ip'
-                                    ) && (
+                                {dataObject[i].hasOwnProperty(
+                                    'fec_destination_ip'
+                                ) && (
+                                    <TextField
+                                        source="fec_destination_ip"
+                                        label="FEC Destination IP"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty('fec_type') && (
+                                    <TextField
+                                        source="fec_type"
+                                        label="FEC Type"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty('fec_mode') && (
+                                    <TextField
+                                        source="fec_mode"
+                                        label="FEC Mode"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec_block_width'
+                                ) && (
+                                    <TextField
+                                        source="fec_block_width"
+                                        label="FEC Block Width"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec_block_height'
+                                ) && (
+                                    <TextField
+                                        source="fec_block_height"
+                                        label="FEC Block Height"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec1D_destination_port'
+                                ) && (
+                                    <TextField
+                                        source="fec1D_destination_port"
+                                        label="FEC1D Destination Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec2D_destination_port'
+                                ) && (
+                                    <TextField
+                                        source="fec2D_destination_port"
+                                        label="FEC2D Destination Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec1D_source_port'
+                                ) && (
+                                    <TextField
+                                        source="fec1D_source_port"
+                                        label="FEC1D source Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'fec2D_source_port'
+                                ) && (
+                                    <TextField
+                                        source="fec2D_source_port"
+                                        label="FEC2D Source Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'rtcp_enabled'
+                                ) && <SanitizedDivider /> && (
+                                        <BooleanField
+                                            source="rtcp_enabled"
+                                            label="RTCP Enabled"
+                                        />
+                                    )}
+                                {dataObject[i].hasOwnProperty(
+                                    'rtcp_destination_ip'
+                                ) && (
+                                    <TextField
+                                        source="rtcp_destination_ip"
+                                        label="RTCP Destination IP"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'rtcp_destination_port'
+                                ) && (
+                                    <TextField
+                                        source="rtcp_destination_port"
+                                        label="RTCP Destination Port"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'rtcp_source_port'
+                                ) && (
+                                    <TextField
+                                        source="rtcp_source_port"
+                                        label="RTCP Source Port"
+                                    />
+                                )}
+                                {params_ext.length !== 0 && (
+                                    <SanitizedDivider />
+                                )}
+                                {params_ext.map(value => {
+                                    return (
                                         <TextField
-                                            source="source_ip"
-                                            label="Source IP"
+                                            record={dataObject[i]}
+                                            source={value}
+                                            key={value}
                                         />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'destination_ip'
-                                    ) && (
-                                        <TextField
-                                            source="destination_ip"
-                                            label="Destination IP"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'source_port'
-                                    ) && (
-                                        <TextField
-                                            source="source_port"
-                                            label="Source Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'destination_port'
-                                    ) && (
-                                        <TextField
-                                            source="destination_port"
-                                            label="Destination Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec_enabled'
-                                    ) && <Divider /> && (
-                                            <BooleanField
-                                                source="fec_enabled"
-                                                label="FEC Enabled"
-                                            />
-                                        )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec_destination_ip'
-                                    ) && (
-                                        <TextField
-                                            source="fec_destination_ip"
-                                            label="FEC Destination IP"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec_type'
-                                    ) && (
-                                        <TextField
-                                            source="fec_type"
-                                            label="FEC Type"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec_mode'
-                                    ) && (
-                                        <TextField
-                                            source="fec_mode"
-                                            label="FEC Mode"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec_block_width'
-                                    ) && (
-                                        <TextField
-                                            source="fec_block_width"
-                                            label="FEC Block Width"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec_block_height'
-                                    ) && (
-                                        <TextField
-                                            source="fec_block_height"
-                                            label="FEC Block Height"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec1D_destination_port'
-                                    ) && (
-                                        <TextField
-                                            source="fec1D_destination_port"
-                                            label="FEC1D Destination Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec2D_destination_port'
-                                    ) && (
-                                        <TextField
-                                            source="fec2D_destination_port"
-                                            label="FEC2D Destination Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec1D_source_port'
-                                    ) && (
-                                        <TextField
-                                            source="fec1D_source_port"
-                                            label="FEC1D source Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'fec2D_source_port'
-                                    ) && (
-                                        <TextField
-                                            source="fec2D_source_port"
-                                            label="FEC2D Source Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'rtcp_enabled'
-                                    ) && <Divider /> && (
-                                            <BooleanField
-                                                source="rtcp_enabled"
-                                                label="RTCP Enabled"
-                                            />
-                                        )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'rtcp_destination_ip'
-                                    ) && (
-                                        <TextField
-                                            source="rtcp_destination_ip"
-                                            label="RTCP Destination IP"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'rtcp_destination_port'
-                                    ) && (
-                                        <TextField
-                                            source="rtcp_destination_port"
-                                            label="RTCP Destination Port"
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'rtcp_source_port'
-                                    ) && (
-                                        <TextField
-                                            source="rtcp_source_port"
-                                            label="RTCP Source Port"
-                                        />
-                                    )}
-                                    {params_ext.length !== 0 && <Divider />}
-                                    {params_ext.map(value => {
-                                        return (
-                                            <TextField
-                                                record={dataObject[i]}
-                                                source={value}
-                                                key={value}
-                                            />
-                                        );
-                                    })}
-                                </SimpleShowLayout>
-                            </CardContent>
-                        </Card>
-                    </Grid>
-                ))}
-            </Grid>
-        </div>
+                                    );
+                                })}
+                            </SimpleShowLayout>
+                        </CardContent>
+                    </Card>
+                </Grid>
+            ))}
+        </Grid>
     );
 };
 
@@ -372,127 +368,109 @@ const RTPSenderEdit = ({ record }) => {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <ArrayInput
-                label="Transport Parameters"
-                source="$staged.transport_params"
-            >
-                <CardFormIterator disableRemove disableAdd>
-                    {uniqueKeys.includes('rtp_enabled') && (
-                        <BooleanInput
-                            source="rtp_enabled"
-                            label="RTP Enabled"
-                        />
-                    )}
-                    {uniqueKeys.includes('source_ip') && (
-                        <TextInput source="source_ip" label="Source IP" />
-                    )}
-                    {uniqueKeys.includes('destination_ip') && (
-                        <TextInput
-                            source="destination_ip"
-                            label="Destination IP"
-                        />
-                    )}
-                    {uniqueKeys.includes('source_port') && (
-                        <TextInput source="source_port" label="Source Port" />
-                    )}
-                    {uniqueKeys.includes('destination_port') && (
-                        <TextInput
-                            source="destination_port"
-                            label="Destination Port"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec_enabled') && (
-                        <BooleanInput
-                            source="fec_enabled"
-                            label="FEC Enabled"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec_destination_ip') && (
-                        <TextInput
-                            source="fec_destination_ip"
-                            label="FEC Destination IP"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec_type') && (
-                        <TextInput source="fec_type" label="FEC Type" />
-                    )}
-                    {uniqueKeys.includes('fec_mode') && (
-                        <TextInput source="fec_mode" label="FEC Mode" />
-                    )}
-                    {uniqueKeys.includes('fec_block_width') && (
-                        <TextInput
-                            source="fec_block_width"
-                            label="FEC Block Width"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec_block_height') && (
-                        <TextInput
-                            source="fec_block_height"
-                            label="FEC Block Height"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec1D_destination_port') && (
-                        <TextInput
-                            source="fec1D_destination_port"
-                            label="FEC1D Destination Port"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec2D_destination_port') && (
-                        <TextInput
-                            source="fec2D_destination_port"
-                            label="FEC2D Destination Port"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec1D_source_port') && (
-                        <TextInput
-                            source="fec1D_source_port"
-                            label="FEC1D Source Port"
-                        />
-                    )}
-                    {uniqueKeys.includes('fec2D_source_port') && (
-                        <TextInput
-                            source="fec2D_source_port"
-                            label="FEC2D Source Port"
-                        />
-                    )}
-                    {uniqueKeys.includes('rtcp_enabled') && (
-                        <BooleanInput
-                            source="rtcp_enabled"
-                            label="RTCP Enabled"
-                        />
-                    )}
-                    {uniqueKeys.includes('rtcp_destination_ip') && (
-                        <TextInput
-                            source="rtcp_destination_ip"
-                            label="RTCP Destination IP"
-                        />
-                    )}
-                    {uniqueKeys.includes('rtcp_destination_port') && (
-                        <TextInput
-                            source="rtcp_destination_port"
-                            label="RTCP Destination Port"
-                        />
-                    )}
-                    {uniqueKeys.includes('rtcp_source_port') && (
-                        <TextInput
-                            source="rtcp_source_port"
-                            label="RTCP Source Port"
-                        />
-                    )}
-                    {params_ext.length !== 0 && <Divider />}
-                    {params_ext.map(value => {
-                        return (
-                            <TextInput
-                                record={record}
-                                source={value}
-                                key={value}
-                            />
-                        );
-                    })}
-                </CardFormIterator>
-            </ArrayInput>
-        </div>
+        <ArrayInput
+            label="Transport Parameters"
+            source="$staged.transport_params"
+        >
+            <CardFormIterator disableRemove disableAdd>
+                {uniqueKeys.includes('rtp_enabled') && (
+                    <BooleanInput source="rtp_enabled" label="RTP Enabled" />
+                )}
+                {uniqueKeys.includes('source_ip') && (
+                    <TextInput source="source_ip" label="Source IP" />
+                )}
+                {uniqueKeys.includes('destination_ip') && (
+                    <TextInput source="destination_ip" label="Destination IP" />
+                )}
+                {uniqueKeys.includes('source_port') && (
+                    <TextInput source="source_port" label="Source Port" />
+                )}
+                {uniqueKeys.includes('destination_port') && (
+                    <TextInput
+                        source="destination_port"
+                        label="Destination Port"
+                    />
+                )}
+                {uniqueKeys.includes('fec_enabled') && (
+                    <BooleanInput source="fec_enabled" label="FEC Enabled" />
+                )}
+                {uniqueKeys.includes('fec_destination_ip') && (
+                    <TextInput
+                        source="fec_destination_ip"
+                        label="FEC Destination IP"
+                    />
+                )}
+                {uniqueKeys.includes('fec_type') && (
+                    <TextInput source="fec_type" label="FEC Type" />
+                )}
+                {uniqueKeys.includes('fec_mode') && (
+                    <TextInput source="fec_mode" label="FEC Mode" />
+                )}
+                {uniqueKeys.includes('fec_block_width') && (
+                    <TextInput
+                        source="fec_block_width"
+                        label="FEC Block Width"
+                    />
+                )}
+                {uniqueKeys.includes('fec_block_height') && (
+                    <TextInput
+                        source="fec_block_height"
+                        label="FEC Block Height"
+                    />
+                )}
+                {uniqueKeys.includes('fec1D_destination_port') && (
+                    <TextInput
+                        source="fec1D_destination_port"
+                        label="FEC1D Destination Port"
+                    />
+                )}
+                {uniqueKeys.includes('fec2D_destination_port') && (
+                    <TextInput
+                        source="fec2D_destination_port"
+                        label="FEC2D Destination Port"
+                    />
+                )}
+                {uniqueKeys.includes('fec1D_source_port') && (
+                    <TextInput
+                        source="fec1D_source_port"
+                        label="FEC1D Source Port"
+                    />
+                )}
+                {uniqueKeys.includes('fec2D_source_port') && (
+                    <TextInput
+                        source="fec2D_source_port"
+                        label="FEC2D Source Port"
+                    />
+                )}
+                {uniqueKeys.includes('rtcp_enabled') && (
+                    <BooleanInput source="rtcp_enabled" label="RTCP Enabled" />
+                )}
+                {uniqueKeys.includes('rtcp_destination_ip') && (
+                    <TextInput
+                        source="rtcp_destination_ip"
+                        label="RTCP Destination IP"
+                    />
+                )}
+                {uniqueKeys.includes('rtcp_destination_port') && (
+                    <TextInput
+                        source="rtcp_destination_port"
+                        label="RTCP Destination Port"
+                    />
+                )}
+                {uniqueKeys.includes('rtcp_source_port') && (
+                    <TextInput
+                        source="rtcp_source_port"
+                        label="RTCP Source Port"
+                    />
+                )}
+                {params_ext.length !== 0 && <SanitizedDivider />}
+                {params_ext.map(value => {
+                    return (
+                        <TextInput record={record} source={value} key={value} />
+                    );
+                })}
+            </CardFormIterator>
+        </ArrayInput>
     );
 };
 
@@ -501,57 +479,58 @@ const WebSocketSender = ({ dataObject }) => {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <Grid container spacing={2}>
-                {Object.keys(dataObject).map(i => (
-                    <Grid item sm key={i}>
-                        <Card elevation={3}>
-                            <CardContent>
-                                <SimpleShowLayout record={dataObject[i]}>
-                                    {dataObject[i].hasOwnProperty(
-                                        'connection_authorization'
-                                    ) && (
-                                        <SelectField
-                                            source="connection_authorization"
-                                            label="Connection Authorization"
-                                            choices={[
-                                                {
-                                                    id: true,
-                                                    name: <CheckIcon />,
-                                                },
-                                                {
-                                                    id: false,
-                                                    name: <ClearIcon />,
-                                                },
-                                                { id: 'auto', name: 'auto' },
-                                            ]}
-                                        />
-                                    )}
-                                    {dataObject[i].hasOwnProperty(
-                                        'connection_uri'
-                                    ) && (
+        <Grid container spacing={2}>
+            {Object.keys(dataObject).map(i => (
+                <Grid item sm key={i}>
+                    <Card elevation={3}>
+                        <CardContent>
+                            <SimpleShowLayout record={dataObject[i]}>
+                                {dataObject[i].hasOwnProperty(
+                                    'connection_authorization'
+                                ) && (
+                                    <SelectField
+                                        source="connection_authorization"
+                                        label="Connection Authorization"
+                                        choices={[
+                                            {
+                                                id: true,
+                                                name: <CheckIcon />,
+                                            },
+                                            {
+                                                id: false,
+                                                name: <ClearIcon />,
+                                            },
+                                            { id: 'auto', name: 'auto' },
+                                        ]}
+                                        translateChoice={false}
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'connection_uri'
+                                ) && (
+                                    <TextField
+                                        source="connection_uri"
+                                        label="Connection URI"
+                                    />
+                                )}
+                                {params_ext.length !== 0 && (
+                                    <SanitizedDivider />
+                                )}
+                                {params_ext.map(value => {
+                                    return (
                                         <TextField
-                                            source="connection_uri"
-                                            label="Connection URI"
+                                            record={dataObject[i]}
+                                            source={value}
+                                            key={value}
                                         />
-                                    )}
-                                    {params_ext.length !== 0 && <Divider />}
-                                    {params_ext.map(value => {
-                                        return (
-                                            <TextField
-                                                record={dataObject[i]}
-                                                source={value}
-                                                key={value}
-                                            />
-                                        );
-                                    })}
-                                </SimpleShowLayout>
-                            </CardContent>
-                        </Card>
-                    </Grid>
-                ))}
-            </Grid>
-        </div>
+                                    );
+                                })}
+                            </SimpleShowLayout>
+                        </CardContent>
+                    </Card>
+                </Grid>
+            ))}
+        </Grid>
     );
 };
 
@@ -566,42 +545,34 @@ const WebSocketSenderEdit = ({ record }) => {
         return x.startsWith('ext_');
     });
     return (
-        <div>
-            <ArrayInput
-                label="Transport Parameters"
-                source="$staged.transport_params"
-            >
-                <CardFormIterator disableRemove disableAdd>
-                    {uniqueKeys.includes('connection_authorization') && (
-                        <SelectInput
-                            source="connection_authorization"
-                            label="Connection Authorization"
-                            choices={[
-                                { id: true, name: <CheckIcon /> },
-                                { id: false, name: <ClearIcon /> },
-                                { id: 'auto', name: 'auto' },
-                            ]}
-                        />
-                    )}
-                    {uniqueKeys.includes('connection_uri') && (
-                        <TextInput
-                            source="connection_uri"
-                            label="Connection URI"
-                        />
-                    )}
-                    {params_ext.length !== 0 && <Divider />}
-                    {params_ext.map(value => {
-                        return (
-                            <TextInput
-                                record={record}
-                                source={value}
-                                key={value}
-                            />
-                        );
-                    })}
-                </CardFormIterator>
-            </ArrayInput>
-        </div>
+        <ArrayInput
+            label="Transport Parameters"
+            source="$staged.transport_params"
+        >
+            <CardFormIterator disableRemove disableAdd>
+                {uniqueKeys.includes('connection_authorization') && (
+                    <SelectInput
+                        source="connection_authorization"
+                        label="Connection Authorization"
+                        choices={[
+                            { id: true, name: <CheckIcon /> },
+                            { id: false, name: <ClearIcon /> },
+                            { id: 'auto', name: 'auto' },
+                        ]}
+                        translateChoice={false}
+                    />
+                )}
+                {uniqueKeys.includes('connection_uri') && (
+                    <TextInput source="connection_uri" label="Connection URI" />
+                )}
+                {params_ext.length !== 0 && <SanitizedDivider />}
+                {params_ext.map(value => {
+                    return (
+                        <TextInput record={record} source={value} key={value} />
+                    );
+                })}
+            </CardFormIterator>
+        </ArrayInput>
     );
 };
 


### PR DESCRIPTION
- Don't attempt to translate objects
- Sanitize props passed to react DOM elements
- Remove redundant refresh prop on receivers list view
- Separate `<Table>` from `<SimpleShowLayout>` components with a <Fragment>
  to prevent props being passed
- Remove redundant `<div>` from card views
- A view raw button has been added to the QueryAPI list and show views
- The connect button has been refactored and a selection menu added
- The QueryAPI show button has been combined with the label
- Padding has been added to the list view