### PR TITLE
When making a connection, force the dataProvider to include rtp_enabled

### DIFF
--- a/Development/src/components/makeConnection.js
+++ b/Development/src/components/makeConnection.js
@@ -183,6 +183,15 @@ const makeConnection = (senderID, receiverID, endpoint) => {
                         '$staged.transport_file.data',
                         get(data.sender, '$transportfile')
                     );
+                    // when preparing a PATCH which might include an SDP file,
+                    // force the dataProvider to include `rtp_enabled`, because
+                    // the spec doesn't define any means to indicate the active
+                    // status of the Sender's legs in the SDP file
+                    const legs = data.receiver.$staged.transport_params.length;
+                    for (let i = 0; i < legs; i++) {
+                        delete data.receiver.$staged.transport_params[i]
+                            .rtp_enabled;
+                    }
                 }
                 set(patchData, '$staged.master_enable', true);
                 set(patchData, '$staged.sender_id', get(data.sender, 'id'));


### PR DESCRIPTION
The spec doesn't define any means to indicate the active status of the Sender's legs in the SDP file, and shows `rtp_enabled` in the Receiver's legs is just set to true or false based on the number of legs in the SDP file, so making this change results in least surprise for users.