### PR TITLE
Fix connect tab removing filter on refresh

### DIFF
--- a/Development/src/components/PaginationButtons.js
+++ b/Development/src/components/PaginationButtons.js
@@ -6,9 +6,8 @@ import {
     LastPage,
 } from '@material-ui/icons';
 import { Button } from '@material-ui/core';
-import Cookies from 'universal-cookie';
-
-const cookies = new Cookies();
+import includes from 'lodash/includes';
+import keys from 'lodash/keys';
 
 const components = {
     prev: ChevronLeft,
@@ -17,19 +16,19 @@ const components = {
     first: FirstPage,
 };
 
-export const PaginationButton = ({ disabled, nextPage, rel, label = rel }) => {
+export const PaginationButton = ({
+    pagination,
+    disabled,
+    nextPage,
+    rel,
+    label = rel,
+}) => {
     rel.toLowerCase();
-    const paginationSupport = cookies.get('Pagination');
+    const buttons = keys(pagination);
+
     const enabled = (() => {
         if (disabled) return false;
-        if (paginationSupport === 'enabled') {
-            return true;
-        } else if (paginationSupport === 'disabled') {
-            return false;
-        } else {
-            // paginationSupport === 'partial'
-            return rel === 'next' || rel === 'prev';
-        }
+        return includes(buttons, rel);
     })();
 
     const getIcon = label => {

--- a/Development/src/components/useGetList.js
+++ b/Development/src/components/useGetList.js
@@ -78,10 +78,10 @@ const useQueryWithStore = (query, options, dataSelector, totalSelector) => {
 const useGetList = props => {
     useCheckMinimumRequiredProps(
         'List',
-        ['basePath', 'filter', 'location', 'resource'],
+        ['basePath', 'filter', 'resource'],
         props
     );
-    const { basePath, resource, hasCreate, paginationURL, filter } = props;
+    const { basePath, resource, paginationURL, filter } = props;
     const debouncedFilter = useDebounce(filter, 250);
 
     const notify = useNotify();
@@ -149,7 +149,6 @@ const useGetList = props => {
         basePath,
         data: listDataArray,
         error,
-        hasCreate,
         ids,
         loading,
         loaded,

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -16,16 +16,6 @@ import assign from 'lodash/assign';
 import diff from 'deep-diff';
 import Cookies from 'universal-cookie';
 
-let LINK_HEADERS = {
-    nodes: '',
-    devices: '',
-    sources: '',
-    flows: '',
-    senders: '',
-    receivers: '',
-    subscriptions: '',
-    logs: '',
-};
 const LOGGING_API = 'Logging API';
 const QUERY_API = 'Query API';
 const DNS_API = 'DNS-SD API';
@@ -429,19 +419,7 @@ const convertHTTPResponseToDataProvider = async (
     params
 ) => {
     const { headers, json } = response;
-    LINK_HEADERS[resource] = headers.get('Link');
-    if (
-        LINK_HEADERS[resource] !== null &&
-        LINK_HEADERS[resource].match(/<([^>]+)>;[ \t]*rel="next"/)
-    ) {
-        if (LINK_HEADERS[resource].match(/<([^>]+)>;[ \t]*rel="first"/)) {
-            cookies.set('Pagination', 'enabled', { path: '/' });
-        } else {
-            cookies.set('Pagination', 'partial', { path: '/' });
-        }
-    } else {
-        cookies.set('Pagination', 'disabled', { path: '/' });
-    }
+
     switch (type) {
         case GET_ONE:
             if (resource === 'queryapis') {
@@ -535,11 +513,12 @@ const convertHTTPResponseToDataProvider = async (
                                       new RegExp(
                                           `<([^>]+)>;[ \\t]*rel="${cursor}"`
                                       )
-                                  )[1],
+                                  ),
                           };
                       })
                       .reduce((object, item) => {
-                          object[item.cursor] = item.data;
+                          if (item.data == null) return object;
+                          object[item.cursor] = item.data[1];
                           return object;
                       }, {})
                 : null;

--- a/Development/src/pages/devices/DevicesList.js
+++ b/Development/src/pages/devices/DevicesList.js
@@ -79,7 +79,7 @@ const DevicesList = props => {
                     </Table>
                     <br />
                     <PaginationButtons
-                        disabled={!pagination}
+                        pagination={pagination}
                         nextPage={nextPage}
                         {...props}
                     />

--- a/Development/src/pages/flows/FlowsList.js
+++ b/Development/src/pages/flows/FlowsList.js
@@ -89,7 +89,7 @@ const FlowsList = props => {
                     </Table>
                     <br />
                     <PaginationButtons
-                        disabled={!pagination}
+                        pagination={pagination}
                         nextPage={nextPage}
                         {...props}
                     />

--- a/Development/src/pages/logs/LogsList.js
+++ b/Development/src/pages/logs/LogsList.js
@@ -92,7 +92,7 @@ const LogsList = props => {
                     </Table>
                     <br />
                     <PaginationButtons
-                        disabled={!pagination}
+                        pagination={pagination}
                         nextPage={nextPage}
                         {...props}
                     />

--- a/Development/src/pages/nodes/NodesList.js
+++ b/Development/src/pages/nodes/NodesList.js
@@ -107,7 +107,7 @@ const NodesList = props => {
                     </Table>
                     <br />
                     <PaginationButtons
-                        disabled={!pagination}
+                        pagination={pagination}
                         nextPage={nextPage}
                         {...props}
                     />

--- a/Development/src/pages/receivers/ConnectionManagementTab.js
+++ b/Development/src/pages/receivers/ConnectionManagementTab.js
@@ -44,7 +44,10 @@ const ConnectionManagementTab = ({ receiverData, basePath }) => {
     // receiverData initialises undefined, update when no longer null
     useEffect(() => {
         if (receiverData !== null)
-            setFilter({ transport: get(receiverData, 'transport') });
+            setFilter(f => ({
+                ...f,
+                transport: get(receiverData, 'transport'),
+            }));
     }, [receiverData]);
 
     if (!loaded) return <Loading />;
@@ -187,7 +190,7 @@ const ConnectionManagementTab = ({ receiverData, basePath }) => {
                     </Table>
                     <br />
                     <PaginationButtons
-                        disabled={!pagination}
+                        pagination={pagination}
                         nextPage={nextPage}
                     />
                 </CardContent>

--- a/Development/src/pages/receivers/ConnectionManagementTab.js
+++ b/Development/src/pages/receivers/ConnectionManagementTab.js
@@ -1,0 +1,199 @@
+import React, { Fragment, useEffect, useState } from 'react';
+import Link from 'react-router-dom/Link';
+import {
+    Card,
+    CardContent,
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableRow,
+} from '@material-ui/core';
+import {
+    Loading,
+    ReferenceField,
+    TextField,
+    TitleForRecord,
+    linkToRecord,
+} from 'react-admin';
+import get from 'lodash/get';
+import useGetList from '../../components/useGetList';
+import FilterPanel, {
+    BooleanFilter,
+    StringFilter,
+} from '../../components/FilterPanel';
+import QueryVersion from '../../components/QueryVersion';
+import ChipConditionalLabel from '../../components/ChipConditionalLabel';
+import ActiveField from '../../components/ActiveField';
+import ConnectButtons from './ConnectButtons';
+import PaginationButtons from '../../components/PaginationButtons';
+import { ReceiversTitle } from './ReceiversShow';
+
+const ConnectionManagementTab = ({ receiverData, basePath }) => {
+    const [filter, setFilter] = useState({
+        transport: get(receiverData, 'transport'),
+    });
+    const [paginationURL, setPaginationURL] = useState(null);
+    const { data, loaded, pagination } = useGetList({
+        basePath,
+        filter,
+        paginationURL,
+        resource: 'senders',
+    });
+
+    // receiverData initialises undefined, update when no longer null
+    useEffect(() => {
+        if (receiverData !== null)
+            setFilter({ transport: get(receiverData, 'transport') });
+    }, [receiverData]);
+
+    if (!loaded) return <Loading />;
+
+    const nextPage = label => {
+        setPaginationURL(pagination[label]);
+    };
+
+    return (
+        <Fragment>
+            <TitleForRecord
+                record={receiverData}
+                title={<ReceiversTitle record={receiverData} />}
+            />
+            <Card>
+                <CardContent>
+                    <FilterPanel
+                        data={data}
+                        filter={filter}
+                        setFilter={setFilter}
+                    >
+                        <StringFilter source="label" label="Sender Label" />
+                        <StringFilter
+                            source="description"
+                            label="Sender Description"
+                        />
+                        {QueryVersion() >= 'v1.2' && (
+                            <BooleanFilter
+                                source="subscription.active"
+                                label="Sender Active"
+                            />
+                        )}
+                        <StringFilter source="id" label="Sender ID" />
+                    </FilterPanel>
+                    <Table>
+                        <TableHead>
+                            <TableRow>
+                                <TableCell
+                                    style={{
+                                        paddingLeft: '32px',
+                                    }}
+                                >
+                                    Sender
+                                </TableCell>
+                                {QueryVersion() >= 'v1.2' && (
+                                    <TableCell>Active</TableCell>
+                                )}
+                                <TableCell>Flow</TableCell>
+                                <TableCell>Format</TableCell>
+                                {QueryVersion() >= 'v1.1' && (
+                                    <TableCell>Media Type</TableCell>
+                                )}
+                                <TableCell>Connect</TableCell>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            {data.map(item => (
+                                <TableRow
+                                    key={item.id}
+                                    selected={
+                                        get(receiverData, 'id') === item.id
+                                    }
+                                >
+                                    <TableCell component="th" scope="row">
+                                        {
+                                            // Using linkToRecord as ReferenceField will
+                                            // make a new unnecessary network request
+                                        }
+                                        <Link
+                                            to={`${linkToRecord(
+                                                '/senders',
+                                                item.id
+                                            )}/show`}
+                                            style={{
+                                                textDecoration: 'none',
+                                            }}
+                                        >
+                                            <ChipConditionalLabel
+                                                record={item}
+                                                source="label"
+                                                label="ra.action.show"
+                                            />
+                                        </Link>
+                                    </TableCell>
+                                    {QueryVersion() >= 'v1.2' && (
+                                        <TableCell>
+                                            <ActiveField
+                                                record={item}
+                                                resource="senders"
+                                            />
+                                        </TableCell>
+                                    )}
+                                    <TableCell>
+                                        <ReferenceField
+                                            record={item}
+                                            basePath="/flows"
+                                            label="Flow"
+                                            source="flow_id"
+                                            reference="flows"
+                                            link="show"
+                                        >
+                                            <ChipConditionalLabel source="label" />
+                                        </ReferenceField>
+                                    </TableCell>
+                                    <TableCell>
+                                        <ReferenceField
+                                            record={item}
+                                            basePath="/flows"
+                                            label="Flow"
+                                            source="flow_id"
+                                            reference="flows"
+                                            link={false}
+                                        >
+                                            <TextField source="format" />
+                                        </ReferenceField>
+                                    </TableCell>
+                                    {QueryVersion() >= 'v1.1' && (
+                                        <TableCell>
+                                            <ReferenceField
+                                                record={item}
+                                                basePath="/flows"
+                                                label="Flow"
+                                                source="flow_id"
+                                                reference="flows"
+                                                link={false}
+                                            >
+                                                <TextField source="media_type" />
+                                            </ReferenceField>
+                                        </TableCell>
+                                    )}
+                                    <TableCell>
+                                        <ConnectButtons
+                                            senderData={item}
+                                            receiverData={receiverData}
+                                        />
+                                    </TableCell>
+                                </TableRow>
+                            ))}
+                        </TableBody>
+                    </Table>
+                    <br />
+                    <PaginationButtons
+                        disabled={!pagination}
+                        nextPage={nextPage}
+                    />
+                </CardContent>
+            </Card>
+        </Fragment>
+    );
+};
+
+export default ConnectionManagementTab;

--- a/Development/src/pages/receivers/ReceiversList.js
+++ b/Development/src/pages/receivers/ReceiversList.js
@@ -101,7 +101,7 @@ const ReceiversList = props => {
                     </Table>
                     <br />
                     <PaginationButtons
-                        disabled={!pagination}
+                        pagination={pagination}
                         nextPage={nextPage}
                         {...props}
                     />

--- a/Development/src/pages/senders/SendersList.js
+++ b/Development/src/pages/senders/SendersList.js
@@ -98,7 +98,7 @@ const SendersList = props => {
                     </Table>
                     <br />
                     <PaginationButtons
-                        disabled={!pagination}
+                        pagination={pagination}
                         nextPage={nextPage}
                         {...props}
                     />

--- a/Development/src/pages/senders/SendersShow.js
+++ b/Development/src/pages/senders/SendersShow.js
@@ -101,43 +101,21 @@ const SendersShow = props => {
                 <span style={{ flexGrow: 1 }} />
                 <ConnectionShowActions {...props} />
             </div>
-            <Route
-                exact
-                path={`${props.basePath}/${props.id}/show/`}
-                render={() => (
-                    <ShowSummaryTab
-                        {...props}
-                        controllerProps={controllerProps}
-                    />
-                )}
-            />
-            <Route
-                exact
-                path={`${props.basePath}/${props.id}/show/active`}
-                render={() => (
-                    <ShowActiveTab
-                        {...props}
-                        controllerProps={controllerProps}
-                    />
-                )}
-            />
-            <Route
-                exact
-                path={`${props.basePath}/${props.id}/show/staged`}
-                render={() => (
-                    <ShowStagedTab
-                        {...props}
-                        controllerProps={controllerProps}
-                    />
-                )}
-            />
+            <Route exact path={`${props.basePath}/${props.id}/show/`}>
+                <ShowSummaryTab {...props} controllerProps={controllerProps} />
+            </Route>
+            <Route exact path={`${props.basePath}/${props.id}/show/active`}>
+                <ShowActiveTab {...props} controllerProps={controllerProps} />
+            </Route>
+            <Route exact path={`${props.basePath}/${props.id}/show/staged`}>
+                <ShowStagedTab {...props} controllerProps={controllerProps} />
+            </Route>
             <Route
                 exact
                 path={`${props.basePath}/${props.id}/show/transportfile`}
-                render={() => (
-                    <ShowTransportFileTab record={controllerProps.record} />
-                )}
-            />
+            >
+                <ShowTransportFileTab record={controllerProps.record} />
+            </Route>
         </Fragment>
     );
 };

--- a/Development/src/pages/sources/SourcesList.js
+++ b/Development/src/pages/sources/SourcesList.js
@@ -76,7 +76,7 @@ const SourcesList = props => {
                     </Table>
                     <br />
                     <PaginationButtons
-                        disabled={!pagination}
+                        pagination={pagination}
                         nextPage={nextPage}
                         {...props}
                     />

--- a/Development/src/pages/subscriptions/SubscriptionsList.js
+++ b/Development/src/pages/subscriptions/SubscriptionsList.js
@@ -106,7 +106,7 @@ const SubscriptionsList = props => {
                         </TableBody>
                     </Table>
                     <PaginationButtons
-                        disabled={!pagination}
+                        pagination={pagination}
                         nextPage={nextPage}
                         {...props}
                     />


### PR DESCRIPTION
- Connect tab has been refactored into a separate file as the logic had nothing in common with the receiver show view.
- To prevent unnecessary recreations of the connect tab, the component is stored as state and only recreated when the receiver data is changed.
- The render prop has been removed from the tab Route components.
- The 'Pagination' cookie was used to communicate the paging capabilities of an API to the list view. Storing this as a cookie caused bugs when multiple requests for different resources are made, ie the connections page.
- The enabled pagination features are now discerned from keys of the pagination prop which was already being passed to the list view.