### PR TITLE
Prototype Receiver Caps

### DIFF
--- a/Development/src/components/ConstraintField.js
+++ b/Development/src/components/ConstraintField.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import get from 'lodash/get';
+import { Typography } from '@material-ui/core';
+
+const renderConstraintValue = value => {
+    return value.numerator
+        ? `${value.numerator} : ${value.denominator ? value.denominator : 1}`
+        : value;
+};
+
+const ConstraintField = ({ record, source }) => {
+    const constraint = get(record, source);
+    const minConstraint = get(constraint, 'minimum');
+    const maxConstraint = get(constraint, 'maximum');
+    const enumConstraint = get(constraint, 'enum');
+    return (
+        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+            {minConstraint != null && (
+                <Typography variant="body2">
+                    {renderConstraintValue(minConstraint)}
+                </Typography>
+            )}
+            {(minConstraint != null || maxConstraint != null) && (
+                <Typography variant="body2">&ndash;</Typography>
+            )}
+            {maxConstraint != null && (
+                <Typography variant="body2">
+                    {renderConstraintValue(maxConstraint)}
+                </Typography>
+            )}
+            {enumConstraint != null && (
+                <Typography variant="body2">
+                    {enumConstraint
+                        .map(item => renderConstraintValue(item))
+                        .join(', ')}
+                </Typography>
+            )}
+        </div>
+    );
+};
+
+ConstraintField.defaultProps = {
+    addLabel: true,
+};
+
+export default ConstraintField;

--- a/Development/src/components/FilterPanel.js
+++ b/Development/src/components/FilterPanel.js
@@ -249,17 +249,17 @@ export const RateFilter = ({
     }, [autoFocus]);
 
     useEffect(() => {
-        // for now, flatten the object here rather than in dataProvider
         setFilter(f => ({
             ...f,
-            [source + '.numerator']: parseInt(value.numerator, 10),
-            [source + '.denominator']: parseInt(value.denominator, 10),
+            [source]: {
+                numerator: parseInt(value.numerator, 10),
+                denominator: parseInt(value.denominator, 10),
+            },
         }));
         return function cleanup() {
             setFilter(f => {
                 let newFilter = { ...f };
-                delete newFilter[source + '.numerator'];
-                delete newFilter[source + '.denominator'];
+                delete newFilter[source];
                 return newFilter;
             });
         };

--- a/Development/src/components/FilterPanel.js
+++ b/Development/src/components/FilterPanel.js
@@ -82,6 +82,31 @@ export const BooleanFilter = ({
     );
 };
 
+export const ConstFilter = ({
+    label,
+    source,
+    filter,
+    setFilter,
+}) => {
+    if (!label) label = titleCase(source);
+
+    useEffect(() => {
+        setFilter(f => ({ ...f, [source]: null }));
+        return function cleanup() {
+            setFilter(f => {
+                let newFilter = { ...f };
+                delete newFilter[source];
+                return newFilter;
+            });
+        };
+    }, [setFilter, source]);
+    return (
+        <div style={{ display: 'flex' }}>
+            <Typography style={{ alignSelf: 'center' }}>{label}</Typography>
+        </div>
+    );
+};
+
 export const NumberFilter = ({
     defaultValue,
     source,

--- a/Development/src/components/FilterPanel.js
+++ b/Development/src/components/FilterPanel.js
@@ -82,12 +82,7 @@ export const BooleanFilter = ({
     );
 };
 
-export const ConstFilter = ({
-    label,
-    source,
-    filter,
-    setFilter,
-}) => {
+export const ConstFilter = ({ label, source, filter, setFilter }) => {
     if (!label) label = titleCase(source);
 
     useEffect(() => {

--- a/Development/src/components/FilterPanel.js
+++ b/Development/src/components/FilterPanel.js
@@ -45,7 +45,7 @@ export const BooleanFilter = ({
         } else if (defaultValue != null) {
             return defaultValue;
         } else {
-            return false;
+            return true;
         }
     });
     if (!label) label = titleCase(source);
@@ -201,13 +201,13 @@ export const RateFilter = ({
     const [value, setValue] = useState(() => {
         if (filter[source] != null) {
             return {
-                numerator: get(defaultValue, 'numerator'),
-                denominator: get(defaultValue, 'denominator'),
+                numerator: get(filter[source], 'numerator'),
+                denominator: get(filter[source], 'denominator'),
             };
         } else if (defaultValue != null) {
             return {
-                numerator: get(filter[source], 'numerator'),
-                denominator: get(filter[source], 'denominator'),
+                numerator: get(defaultValue, 'numerator'),
+                denominator: get(defaultValue, 'denominator'),
             };
         } else {
             return {

--- a/Development/src/components/RateField.js
+++ b/Development/src/components/RateField.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import get from 'lodash/get';
+import { Typography } from '@material-ui/core';
+
+const RateField = ({ record, source }) => {
+    const rate = get(record, source);
+    return (
+        <Typography variant="body2">
+            {rate.numerator} : {rate.denominator ? rate.denominator : 1}
+        </Typography>
+    );
+};
+
+RateField.defaultProps = {
+    addLabel: true,
+};
+
+export default RateField;

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -372,6 +372,9 @@ const convertDataProviderRequestToHTTP = (
                     };
 
                     const paramConstraintMap = {
+                        // General Constraints
+                        'urn:x-nmos:cap:format:media_type': constraint =>
+                            generateFilterRQL(constraint, 'media_type'),
                         // If grain_rate is not expressed in the flow, fall back to querying the source
                         'urn:x-nmos:cap:format:grain_rate': constraint => {
                             const filter = generateFilterRQL(
@@ -389,7 +392,7 @@ const convertDataProviderRequestToHTTP = (
                                 ')))'
                             );
                         },
-                        //Video Constraints
+                        // Video Constraints
                         'urn:x-nmos:cap:format:frame_height': constraint =>
                             generateFilterRQL(constraint, 'frame_height'),
                         'urn:x-nmos:cap:format:frame_width': constraint =>
@@ -415,7 +418,7 @@ const convertDataProviderRequestToHTTP = (
                                 'transfer_characteristic',
                                 'SDR'
                             ),
-                        //urn:x-nmos:cap:format:component_depth TODO:
+                        // TODO: urn:x-nmos:cap:format:component_depth
                         // Audio Constraints
                         // Channel count is not expressed in the flow, but is implicitly expressed in the source
                         'urn:x-nmos:cap:format:channel_count': constraint =>
@@ -435,9 +438,9 @@ const convertDataProviderRequestToHTTP = (
                         'urn:x-nmos:cap:format:event_type': constraint =>
                             generateFilterRQL(constraint, 'event_type'),
                         // Transport Constraints
-                        //urn:x-nmos:cap:transport:packet_time TODO:
-                        //urn:x-nmos:cap:transport:max_packet_time TODO:
-                        //urn:x-nmos:cap:transport:st2110_21_sender_type TODO:
+                        //TODO: urn:x-nmos:cap:transport:packet_time
+                        //TODO: urn:x-nmos:cap:transport:max_packet_time
+                        //TODO: urn:x-nmos:cap:transport:st2110_21_sender_type
                     };
                     const constraintSetsFilters = [];
                     for (const constraintSet of constraintSets) {
@@ -738,11 +741,9 @@ const filterResult = async (json, referenceFilter) => {
         //hm, this could be parallelized too?
         for (const ref in referenceFilter) {
             const id = object[ref + '_id'];
-            const data = (
-                await dataProvider(GET_LIST, ref + 's', {
-                    filter: { ...referenceFilter[ref], id: id },
-                })
-            ).data;
+            const data = (await dataProvider(GET_LIST, ref + 's', {
+                filter: { ...referenceFilter[ref], id: id },
+            })).data;
             if (data.length === 0) return false;
         }
         return true;

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -307,7 +307,7 @@ const convertDataProviderRequestToHTTP = (
 
                 if (constraintSets && constraintSetsActive !== undefined) {
 
-                    const rationalTransform = v => 'rational:' + encodeRQLNameChars(get(v, 'numerator') + '/' + get(v, 'denominator'));
+                    const rationalTransform = v => 'rational:' + encodeRQLNameChars(get(v, 'numerator') + '/' + get(v, 'denominator', 1.0));
                     const identityTransform = v => encodeRQLNameChars(v);
                     const samplingTransform = v => 'sampling:' + encodeRQLNameChars(v);
 
@@ -387,11 +387,6 @@ const convertDataProviderRequestToHTTP = (
                         //urn:x-nmos:cap:transport:packet_time
                         //urn:x-nmos:cap:transport:max_packet_time
                         //urn:x-nmos:cap:transport:st2110_21_sender_type
-                        //urn:x-nmos:cap:transport:st2110_21_tr_offset
-                        //urn:x-nmos:cap:transport:bandwidth
-                        //urn:x-nmos:cap:transport:fec_scheme_id
-
-
                     };
                     const constraintSetsFilters = [];
                     for (const constraintSet of constraintSets) {

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -367,6 +367,7 @@ const convertDataProviderRequestToHTTP = (
                     const constraintSetsFilters = [];
                     for (const constraintSet of constraintSets) {
                         // ignore a contraint_set if the enabled flag is set to false
+                        // note that constraintSet['urn:x-nmos:cap:meta:enabled'] being undefined is considered as enabled=true
                         if (constraintSet['urn:x-nmos:cap:meta:enabled'] === false) {
                             continue;
                         }

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -432,9 +432,7 @@ const convertDataProviderRequestToHTTP = (
                         ','
                     );
                     if (constraintSetsFilter) {
-                        flowFilters.push(
-                            'or(' + constraintSetsFilter + ')'
-                        );
+                        flowFilters.push('or(' + constraintSetsFilter + ')');
                     }
                 }
                 const flowFilter = flowFilters.join(',');

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -258,11 +258,11 @@ const paramConstraintMap = {
     'urn:x-nmos:cap:format:transfer_characteristic': constraint =>
         encodeRQLConstraint(constraint, 'transfer_characteristic', 'SDR'),
     // check bit depths of *all* components satisfy the constraint
-    // using the experimental extension to 'rel' and a double negation
+    // using the experimental 'sub' call-operator and a double negation
     // i.e. constraint is *not* satisfied when *any* component's bit depth is *not* acceptable
     'urn:x-nmos:cap:format:component_depth': constraint => {
         const filter = encodeRQLConstraint(constraint, 'bit_depth');
-        return 'not(rel(components,not(' + filter + ')))';
+        return 'not(sub(components,not(' + filter + ')))';
     },
 
     // Audio Constraints

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -316,7 +316,13 @@ const convertDataProviderRequestToHTTP = (
                         }
 
                         if (has(constraint, 'enum')) {
-                            terms.push('in(' + name + ',(' + get(constraint, 'enum').map(parameterTransform).join(',') + '))');
+                            const enumConstraint = get(constraint, 'enum').map(parameterTransform);
+
+                            // if the constraint is the parameter default then sender support may be implicit (i.e. may not be explicitly stated)
+                            if (enumConstraint.includes(defaultValue)) {
+                                enumConstraint.push('null');
+                            }
+                            terms.push('in(' + name + ',(' + enumConstraint.join(',') + '))');
                         }
 
                         if (terms.length > 1) {
@@ -360,6 +366,10 @@ const convertDataProviderRequestToHTTP = (
                     };
                     const constraintSetsFilters = [];
                     for (const constraintSet of constraintSets) {
+                        // ignore a contraint_set if the enabled flag is set to false
+                        if (constraintSet['urn:x-nmos:cap:meta:enabled'] === false) {
+                            continue;
+                        }
                         const paramFilters = [];
                         for (const paramConstraint in constraintSet) {
                             if (paramConstraint in paramConstraintMap) {

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -297,14 +297,6 @@ const convertDataProviderRequestToHTTP = (
                     '$constraint_sets_active'
                 );
 
-                // add defaults for not required constraints if they don't exist
-                if (constraintSets && !has(constraintSets[0], 'urn:x-nmos:cap:format:transfer_characteristic')) {
-                    constraintSets[0]['urn:x-nmos:cap:format:transfer_characteristic'] = { enum: ['SDR'] };
-                }
-                if (constraintSets && !has(constraintSets[0], 'urn:x-nmos:cap:format:interlace_mode')) {
-                    constraintSets[0]['urn:x-nmos:cap:format:interlace_mode'] = { enum: ['progressive'] };
-                }
-
                 if (constraintSets && constraintSetsActive !== undefined) {
 
                     const rationalTransform = v => 'rational:' + encodeRQLNameChars(get(v, 'numerator') + '/' + get(v, 'denominator', 1.0));

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -418,7 +418,16 @@ const convertDataProviderRequestToHTTP = (
                                 'transfer_characteristic',
                                 'SDR'
                             ),
-                        // TODO: urn:x-nmos:cap:format:component_depth
+                        // Check bit depths of *all* components satisfy the constraint
+                        // using the experimental extension to 'rel' and a double negation
+                        // i.e. constraint is *not* satisfied when *any* component's bit depth is *not* acceptable
+                        'urn:x-nmos:cap:format:component_depth': constraint => {
+                            const filter = generateFilterRQL(
+                                constraint,
+                                'bit_depth'
+                            );
+                            return 'not(rel(components,not(' + filter + ')))';
+                        },
                         // Audio Constraints
                         // Channel count is not expressed in the flow, but is implicitly expressed in the source
                         'urn:x-nmos:cap:format:channel_count': constraint =>

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -432,15 +432,9 @@ const convertDataProviderRequestToHTTP = (
                         ','
                     );
                     if (constraintSetsFilter) {
-                        if (constraintSetsActive) {
-                            flowFilters.push(
-                                'or(' + constraintSetsFilter + ')'
-                            );
-                        } else {
-                            flowFilters.push(
-                                'not(or(' + constraintSetsFilter + '))'
-                            );
-                        }
+                        flowFilters.push(
+                            'or(' + constraintSetsFilter + ')'
+                        );
                     }
                 }
                 const flowFilter = flowFilters.join(',');

--- a/Development/src/pages/flows/FlowsShow.js
+++ b/Development/src/pages/flows/FlowsShow.js
@@ -16,6 +16,7 @@ import {
 } from 'react-admin';
 import MapObject from '../../components/ObjectField';
 import RawButton from '../../components/RawButton';
+import RateField from '../../components/RateField';
 import TAIField from '../../components/TAIField';
 import QueryVersion from '../../components/QueryVersion';
 import ChipConditionalLabel from '../../components/ChipConditionalLabel';
@@ -64,18 +65,7 @@ const FlowsShow = props => {
                 />
                 <hr />
                 {controllerProps.record && QueryVersion() >= 'v1.1' && (
-                    <FunctionField
-                        label="Grain Rate"
-                        render={record =>
-                            record.grain_rate
-                                ? `${record.grain_rate.numerator} : ${
-                                      record.grain_rate.denominator
-                                          ? record.grain_rate.denominator
-                                          : 1
-                                  }`
-                                : null
-                        }
-                    />
+                    <RateField label="Grain Rate" source="grain_rate" />
                 )}
                 <TextField source="format" />
                 {controllerProps.record && QueryVersion() >= 'v1.1' && (
@@ -132,6 +122,12 @@ const FlowsShow = props => {
                             label="Transfer Characteristic"
                             source="transfer_characteristic"
                         />
+                    )}
+                {controllerProps.record &&
+                    QueryVersion() >= 'v1.1' &&
+                    controllerProps.record.format ===
+                        'urn:x-nmos:format:audio' && (
+                        <RateField label="Sample Rate" source="sample_rate" />
                     )}
                 {controllerProps.record &&
                     QueryVersion() >= 'v1.1' &&

--- a/Development/src/pages/receivers/ConnectionManagementTab.js
+++ b/Development/src/pages/receivers/ConnectionManagementTab.js
@@ -41,6 +41,7 @@ const ConnectionManagementTab = ({ receiverData, basePath }) => {
             ...(QueryVersion() >= 'v1.3' && {
                 '$flow.event_type': get(receiverData, 'caps.event_types'),
             }),
+            $constraint_sets: get(receiverData, 'caps.constraint_sets'),
         };
     }, [receiverData]);
 
@@ -120,6 +121,11 @@ const ConnectionManagementTab = ({ receiverData, basePath }) => {
                                 label="Flow Event Type"
                             />
                         )}
+                        <BooleanFilter
+                            defaultValue={true}
+                            source="$constraint_sets_active"
+                            label="Constraint Sets"
+                        />
                     </FilterPanel>
                     <Table>
                         <TableHead>

--- a/Development/src/pages/receivers/ConnectionManagementTab.js
+++ b/Development/src/pages/receivers/ConnectionManagementTab.js
@@ -9,6 +9,7 @@ import {
     TableHead,
     TableRow,
 } from '@material-ui/core';
+import Cookies from 'universal-cookie';
 import {
     Loading,
     ReferenceField,
@@ -29,6 +30,8 @@ import ActiveField from '../../components/ActiveField';
 import ConnectButtons from './ConnectButtons';
 import PaginationButtons from '../../components/PaginationButtons';
 import { ReceiversTitle } from './ReceiversShow';
+
+const cookies = new Cookies();
 
 const ConnectionManagementTab = ({ receiverData, basePath }) => {
     const baseFilter = useMemo(() => {
@@ -121,11 +124,13 @@ const ConnectionManagementTab = ({ receiverData, basePath }) => {
                                 label="Flow Event Type"
                             />
                         )}
-                        <BooleanFilter
-                            defaultValue={true}
-                            source="$constraint_sets_active"
-                            label="Constraint Sets"
-                        />
+                        {cookies.get('RQL') !== 'false' && (
+                            <BooleanFilter
+                                defaultValue={true}
+                                source="$constraint_sets_active"
+                                label="Constraint Sets"
+                            />
+                        )}
                     </FilterPanel>
                     <Table>
                         <TableHead>

--- a/Development/src/pages/receivers/ConnectionManagementTab.js
+++ b/Development/src/pages/receivers/ConnectionManagementTab.js
@@ -21,6 +21,7 @@ import get from 'lodash/get';
 import useGetList from '../../components/useGetList';
 import FilterPanel, {
     BooleanFilter,
+    ConstFilter,
     RateFilter,
     StringFilter,
 } from '../../components/FilterPanel';
@@ -125,8 +126,7 @@ const ConnectionManagementTab = ({ receiverData, basePath }) => {
                             />
                         )}
                         {cookies.get('RQL') !== 'false' && (
-                            <BooleanFilter
-                                defaultValue={true}
+                            <ConstFilter
                                 source="$constraint_sets_active"
                                 label="Constraint Sets"
                             />

--- a/Development/src/pages/receivers/ReceiverConstraintSets.js
+++ b/Development/src/pages/receivers/ReceiverConstraintSets.js
@@ -1,0 +1,211 @@
+import React from 'react';
+import { Card, CardContent, Grid } from '@material-ui/core';
+import { SelectField, SimpleShowLayout, TextField } from 'react-admin';
+import ConstraintField from '../../components/ConstraintField';
+import CheckIcon from '@material-ui/icons/Check';
+import ClearIcon from '@material-ui/icons/Clear';
+
+const ReceiverConstraintSets = ({ dataObject }) => {
+    return (
+        <Grid container spacing={2}>
+            {Object.keys(dataObject).map(i => (
+                <Grid item sm key={i}>
+                    <Card elevation={3}>
+                        <CardContent>
+                            <SimpleShowLayout record={dataObject[i]}>
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:meta:label'
+                                ) && (
+                                    <TextField
+                                        source="urn:x-nmos:cap:meta:label"
+                                        label="Label"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:meta:enabled'
+                                ) && (
+                                    <SelectField
+                                        source="urn:x-nmos:cap:meta:enabled"
+                                        label="Enabled"
+                                        choices={[
+                                            {
+                                                id: true,
+                                                name: <CheckIcon />,
+                                            },
+                                            {
+                                                id: false,
+                                                name: <ClearIcon />,
+                                            },
+                                        ]}
+                                        translateChoice={false}
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:meta:preference'
+                                ) && (
+                                    <TextField
+                                        source="urn:x-nmos:cap:meta:preference"
+                                        label="Preference"
+                                    />
+                                )}
+                                {
+                                    // General Constraints
+                                }
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:media_type'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:media_type"
+                                        label="Media Type"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:grain_rate'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:grain_rate"
+                                        label="Grain Rate"
+                                    />
+                                )}
+                                {
+                                    // Video Constraints
+                                }
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:frame_width'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:frame_width"
+                                        label="Frame Width"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:frame_height'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:frame_height"
+                                        label="Frame Height"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:color_sampling'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:color_sampling"
+                                        label="Color Sampling"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:interlace_mode'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:interlace_mode"
+                                        label="Interlace Mode"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:colorspace'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:colorspace"
+                                        label="Colorspace"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:transfer_characteristic'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:transfer_characteristic"
+                                        label="Transfer Characteristic"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:component_depth'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:component_depth"
+                                        label="Component Depth"
+                                    />
+                                )}
+                                {
+                                    // Audio Constraints
+                                }
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:channel_count'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:channel_count"
+                                        label="Channel Count"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:sample_rate'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:sample_rate"
+                                        label="Sample Rate"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:sample_depth'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:sample_depth"
+                                        label="Sample Depth"
+                                    />
+                                )}
+                                {
+                                    // Event Constraints
+                                }
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:format:event_type'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:format:event_type"
+                                        label="Event Type"
+                                    />
+                                )}
+                                {
+                                    // Transport Constraints
+                                }
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:transport:packet_time'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:transport:packet_time"
+                                        label="Packet Time (ms)"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:transport:max_packet_time'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:transport:max_packet_time"
+                                        label="Max Packet Time (ms)"
+                                    />
+                                )}
+                                {dataObject[i].hasOwnProperty(
+                                    'urn:x-nmos:cap:transport:st2110_21_sender_type'
+                                ) && (
+                                    <ConstraintField
+                                        source="urn:x-nmos:cap:transport:st2110_21_sender_type"
+                                        label="ST 2110-21 Sender Type"
+                                    />
+                                )}
+                            </SimpleShowLayout>
+                        </CardContent>
+                    </Card>
+                </Grid>
+            ))}
+        </Grid>
+    );
+};
+
+const ReceiverConstraintSetCardsGrid = ({ ids, record }) => {
+    const dataObject = [];
+    for (let i in ids) {
+        dataObject.push(JSON.parse(ids[i]));
+    }
+    return <ReceiverConstraintSets dataObject={dataObject} />;
+};
+
+export default ReceiverConstraintSetCardsGrid;

--- a/Development/src/pages/receivers/ReceiversShow.js
+++ b/Development/src/pages/receivers/ReceiversShow.js
@@ -19,6 +19,7 @@ import ConnectionShowActions from '../../components/ConnectionShowActions';
 import ItemArrayField from '../../components/ItemArrayField';
 import JSONViewer from '../../components/JSONViewer';
 import QueryVersion from '../../components/QueryVersion';
+import ReceiverConstraintSetCardsGrid from './ReceiverConstraintSets';
 import ReceiverTransportParamsCardsGrid from './ReceiverTransportParams';
 import MapObject from '../../components/ObjectField';
 import TAIField from '../../components/TAIField';
@@ -173,6 +174,21 @@ const ShowSummaryTab = ({ controllerProps, ...props }) => {
                             label="Event Types Capability"
                             source="caps.event_types"
                         />
+                    )}
+                {controllerProps.record &&
+                    controllerProps.record.caps.constraint_sets && (
+                        <ArrayField
+                            label="Constraint Sets"
+                            source="caps.constraint_sets"
+                        >
+                            <ReceiverConstraintSetCardsGrid
+                                record={controllerProps.record}
+                            />
+                        </ArrayField>
+                    )}
+                {controllerProps.record &&
+                    controllerProps.record.caps.version && (
+                        <TAIField source="version" />
                     )}
                 <TextField source="format" />
                 {controllerProps.record && QueryVersion() >= 'v1.2' && (

--- a/Development/src/pages/settings.js
+++ b/Development/src/pages/settings.js
@@ -60,10 +60,6 @@ const paging = [
     },
 ];
 
-function getBool(cookie) {
-    return cookie !== 'false';
-}
-
 const Settings = () => {
     const classes = useStyles();
     const [values, setValues] = React.useState({
@@ -71,7 +67,7 @@ const Settings = () => {
         loggingAPI: changeAPIEndpoint('Logging API', ''),
         dnssdAPI: changeAPIEndpoint('DNS-SD API', ''),
         paging: parseInt(changePaging('valueRequest'), 10),
-        rql: getBool(cookies.get('RQL')),
+        rql: cookies.get('RQL') !== 'false',
     });
 
     const handleInputChange = name => event => {

--- a/Development/src/pages/sources/SourcesShow.js
+++ b/Development/src/pages/sources/SourcesShow.js
@@ -16,6 +16,7 @@ import {
 } from 'react-admin';
 import MapObject from '../../components/ObjectField';
 import RawButton from '../../components/RawButton';
+import RateField from '../../components/RateField';
 import TAIField from '../../components/TAIField';
 import QueryVersion from '../../components/QueryVersion';
 import ChipConditionalLabel from '../../components/ChipConditionalLabel';
@@ -64,18 +65,7 @@ const SourcesShow = props => {
                 />
                 <hr />
                 {controllerProps.record && QueryVersion() >= 'v1.1' && (
-                    <FunctionField
-                        label="Grain Rate"
-                        render={record =>
-                            record.grain_rate
-                                ? `${record.grain_rate.numerator} : ${
-                                      record.grain_rate.denominator
-                                          ? record.grain_rate.denominator
-                                          : 1
-                                  }`
-                                : null
-                        }
-                    />
+                    <RateField label="Grain Rate" source="grain_rate" />
                 )}
                 {controllerProps.record && QueryVersion() >= 'v1.1' && (
                     <TextField label="Clock Name" source="clock_name" />


### PR DESCRIPTION
Add filtering of Senders based on Constraint Sets to the Receiver connect tab.

Also add the Constraint Sets to the Receiver summary tab.

Uses RQL on the Query API to implement the Constraint Keywords defined by the [proposed BCP-004-01 Receiver Capabilities spec](https://github.com/AMWA-TV/nmos-receiver-capabilities/blob/v1.0-dev/docs/1.0.%20Receiver%20Capabilities.md) for most of the Parameter Constraints initially listed in the [proposed Capabilities register](https://github.com/AMWA-TV/nmos-parameter-registers/blob/capabilities/capabilities/README.md). 
