### PR TITLE
Pin Dockerfile to node:22 LTS to restore Docker build

### DIFF
--- a/Development/Dockerfile
+++ b/Development/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest AS build
+FROM node:22 AS build
 WORKDIR /usr/src/app
 COPY package.json yarn.lock ./
 RUN yarn


### PR DESCRIPTION
## Summary

- Pins `Development/Dockerfile` from `FROM node:latest` to `FROM node:22 AS build`.
- Restores the documented `docker build -t nmos-js Development` quick-start, which currently fails with `yarn: not found` because `node:latest` (Node 26.1.0) no longer bundles `yarn` or `corepack`.
- One-line change; no other modifications.

Fixes #144.

## Background

`node:latest` historically shipped a pre-installed `yarn` binary, which `RUN yarn` in the Dockerfile relied on. Recent upstream Node Docker images have dropped both `yarn` and `corepack`:

```
$ docker run --rm node:latest sh -c 'node -v; yarn -v 2>/dev/null || echo missing; corepack -v 2>/dev/null || echo missing'
v26.1.0
missing
missing
```

The active LTS line (`node:22`) still ships `yarn 1.22.22`, so pinning to it is the minimum change that restores the build. This is also consistent with the Node 20+ dependency work that landed in #98.

This regression is invisible in CI because `.github/workflows/build-test.yml` uses `actions/setup-node@v4` on a GitHub-hosted runner that provides `yarn` system-wide; the Dockerfile path is not exercised by the matrix.

## Test plan

- [x] `docker build -t nmos-js Development` succeeds on a clean machine with this change (verified locally; nginx-served React shell returns HTTP 200 from the resulting image).
- [ ] Reviewer runs `docker build -t nmos-js Development` against `master` to confirm the failure, then against this branch to confirm the fix.
- [ ] Optional: consider adding a Docker build job to `.github/workflows/build-test.yml` so future regressions in the Docker path are caught in CI. Not included here to keep the diff focused.