### PR TITLE
Add Status Monitor Panels to IS-12 Client

### DIFF
--- a/is12-client/src/client/DataTables.js
+++ b/is12-client/src/client/DataTables.js
@@ -9,8 +9,6 @@ import TableRow from "@mui/material/TableRow";
 import TableCell from "@mui/material/TableCell";
 import TableBody from "@mui/material/TableBody";
 import {useContext, useState} from "react";
-import UploadIcon from "@mui/icons-material/Backup";
-import EditIcon from "@mui/icons-material/Edit";
 import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import SendIcon from '@mui/icons-material/Send';
@@ -19,6 +17,15 @@ import { DataProviderContext } from "./NCAController";
 import { makePropValue, makeStructValue, makeSequenceValue, isReadOnly, isStructDatatype } from "../middleware/HelperFunctions";
 import { PROPERTY_IDS } from "../global/IS12CommandTemplates";
 import { NcDatatypeType } from "../global/Types"
+import EditablePropertyControl from "./EditablePropertyControl";
+import StatusMonitorList from "./statusMonitor/StatusMonitorList";
+import StatusMonitorTabSummary from "./statusMonitor/StatusMonitorTabSummary";
+import {
+    getStatusMonitorNodes,
+    getNonStatusMonitorChildNodes,
+    isStatusMonitor,
+    subtreeContainsStatusMonitor,
+} from "./statusMonitor/statusMonitorUtils";
 
 import {
     Box,
@@ -29,10 +36,6 @@ import {
     FormControl,
     Grid,
     IconButton,
-    InputLabel,
-    MenuItem,
-    OutlinedInput,
-    Select,
     Typography
 } from "@mui/material";
 
@@ -112,6 +115,12 @@ function Tab(valueRow) {
                 <Grid>
                     <Typography component="h3" variant="h6" color="white" gutterBottom> { node.name } </Typography>
                 </Grid>
+                {!openTab && subtreeContainsStatusMonitor(node) ?
+                    <Grid sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', pl: 1, pb: 1 }}>
+                        <StatusMonitorTabSummary monitors={getStatusMonitorNodes(node)} />
+                    </Grid>
+                    : null
+                }
             </Box>
             <Collapse in={openTab} timeout='auto' unmountOnExit>
                 <BlockTable key={node.name} row={node} state={state}/>
@@ -121,37 +130,77 @@ function Tab(valueRow) {
 }
 
 // JSX Element for most rows
+function BlockDescriptionRow({ row }) {
+    return (
+        <TableRow>
+            <TableCell sx={{ width: '35%' }}>{row.description}</TableCell>
+            <TableCell sx={{ width: '20%' }}><UserLabelSection row={row.valueHolderMap} oid={row.oid}/></TableCell>
+        </TableRow>
+    );
+}
+
 function BlockTable(valueRow) {
-    const { row } = valueRow;
-    const { state } = valueRow;
+    const { row, state, renderedMonitorOids } = valueRow;
+    const seenMonitors = renderedMonitorOids || new Set();
+    const nonMonitorChildNodes = getNonStatusMonitorChildNodes(row);
+
+    if (isStatusMonitor(row.classId)) {
+        if (seenMonitors.has(row.oid)) {
+            return null;
+        }
+
+        seenMonitors.add(row.oid);
+        return <StatusMonitorList monitors={[row]} />;
+    }
+
+    const statusMonitors = getStatusMonitorNodes(row).filter((monitor) => !seenMonitors.has(monitor.oid));
+    statusMonitors.forEach((monitor) => seenMonitors.add(monitor.oid));
+
+    const bodyContent = statusMonitors.length > 0 ? (
+        <>
+            <StatusMonitorList monitors={statusMonitors} />
+            {nonMonitorChildNodes.length > 0 ?
+                <ChildBlockTable
+                    key={row.name + 'blocks'}
+                    row={{ ...row, childNodes: nonMonitorChildNodes }}
+                    state={state}
+                    renderedMonitorOids={seenMonitors}
+                />
+                : null
+            }
+            {row.methods !== null & Object.keys(row.methods).length > 0 ?
+                <MethodsTable key={row.name + 'methods'} row={row} state={state}/>
+                : null
+            }
+        </>
+    ) : (
+        <>
+            {row.childNodes.length > 0 ?
+                <ChildBlockTable key={row.name + 'blocks'} row={row} state={state} renderedMonitorOids={seenMonitors}/>
+                : null
+            }
+            {row.valueHolderMap !== null && Object.keys(row.valueHolderMap).length > 0 ?
+                <PropsTable key={row.name + 'props'} row={row} state={state} />
+                : null
+            }
+            {row.methods !== null & Object.keys(row.methods).length > 0 ?
+                <MethodsTable key={row.name + 'methods'} row={row} state={state}/>
+                : null
+            }
+        </>
+    );
 
     return (
-        <>
-            <Table stickyHeader aria-label='collapsible table'>
-                <TableBody>
-                    <TableRow>
-                        <TableCell sx={{ width: '35%' }}>{row.description}</TableCell>
-                        <TableCell sx={{ width: '20%' }}><UserLabelSection row={row.valueHolderMap} oid={row.oid}/></TableCell>
-                    </TableRow>
-                    <TableRow>
+        <Table stickyHeader aria-label='collapsible table'>
+            <TableBody>
+                <BlockDescriptionRow row={row} />
+                <TableRow>
                     <TableCell colSpan={2}>
-                    {row.childNodes.length > 0 ?
-                        <ChildBlockTable key={row.name + 'blocks'} row={row} state={state}/>
-                        : null
-                    }
-                    {row.valueHolderMap !== null && Object.keys(row.valueHolderMap).length > 0 ?
-                        <PropsTable key={row.name + 'props'} row={row} state={state} />
-                        : null
-                    }
-                    {row.methods !== null & Object.keys(row.methods).length > 0 ?
-                        <MethodsTable key={row.name + 'methods'} row={row} state={state}/>
-                        : null
-                    }
+                        {bodyContent}
                     </TableCell>
-                    </TableRow>
-                </TableBody>
-            </Table>
-        </>
+                </TableRow>
+            </TableBody>
+        </Table>
     );
 }
 
@@ -159,6 +208,7 @@ function BlockTable(valueRow) {
 function ChildBlockTable(valueRow) {
     const { row } = valueRow;
     const { state } = valueRow;
+    const { renderedMonitorOids } = valueRow;
 
     const [openBlock, setOpenBlock] = useState(false);
 
@@ -178,8 +228,14 @@ function ChildBlockTable(valueRow) {
             </Box>
             <Collapse in={openBlock} timeout='auto' unmountOnExit>
                 <Box sx={{ margin: 1 }}>
-                    {row.childNodes.map((child) => <BlockTable key={child.name + 'childblock'} row={child} state={state} />
-                    )}
+                    {row.childNodes.map((child) => (
+                        <BlockTable
+                            key={child.name + 'childblock'}
+                            row={child}
+                            state={state}
+                            renderedMonitorOids={renderedMonitorOids}
+                        />
+                    ))}
                 </Box>
             </Collapse>
         </>
@@ -531,7 +587,17 @@ function EditableProperty(valueRow) {
         index: Number(formattedId[1])
     }
 
-    return CreateEditableProperty(row.valueHolder, row.oid, propertyId, isMethod, structValue, index, parameterName)
+    return (
+        <EditablePropertyControl
+            valueHolder={row.valueHolder}
+            oid={row.oid}
+            propertyId={propertyId}
+            isMethod={isMethod}
+            structValue={structValue}
+            index={index}
+            parameterName={parameterName}
+        />
+    );
 }
 
 /**
@@ -543,193 +609,13 @@ function UserLabelSection(props) {
 
     let userLabel = row["1.6"]
 
-    return CreateEditableProperty(userLabel, oid, PROPERTY_IDS.OBJECT.USER_LABEL, false, undefined, undefined, undefined)
-}
-
-// need to use state of underlying array in state not value of single element
-function CreateEditableProperty(row, oid, propertyId, isMethod, structValue, index, parameterName) {
-    let valueHolder = row
-    let datatype = valueHolder.datatype
-    let value = valueHolder.value
-    let invariantType = undefined // use by method parameters where we have an invariant type ("any") and need to hint what the cast should be
-
-    let isSequence = index !== undefined
-
-    const [editable, setEditable] = useState(false)
-    const [newValue, setNewValue] = useState(value)
-    const [newInvariantType, setInvariantType] = useState(invariantType)
-
-    const DataProvider = useContext(DataProviderContext)
-
-    // If datatype is null then this property is an invariant 'any' property. Model as a string
-    if (datatype && datatype.type === NcDatatypeType.NcEnum) {
-        return (
-            <>
-                {/* DROP DOWN LIST: */}
-                <FormControl fullWidth>
-                    <Select
-                        labelId="demo-simple-select-label"
-                        id="demo-simple-select"
-                        sx={{ fontSize: '0.9rem', width: `${((value ? value.length : 5)/ 2.5) + 3}rem`, maxWidth: '14rem' }}
-                        size='small'
-                        value={value}
-                        onChange={(e) => {
-                            setNewValue(e.target.value)
-                            if(isMethod){
-                                if(isSequence) {
-                                    DataProvider.changeSequenceParameter(oid, propertyId, index, parameterName, e.target.value, structValue, valueHolder)
-                                }else{
-                                    DataProvider.changeParameter(oid, propertyId, parameterName, e.target.value, structValue, valueHolder)
-                                }
-                            }
-                            else {
-                                if(isSequence) {
-                                    DataProvider.changeSequencePropertyValue(oid, propertyId, index, e.target.value, structValue, valueHolder)
-                                }else{
-                                    DataProvider.changeValue(oid, propertyId, e.target.value, structValue, valueHolder)
-                                }
-                            }
-                        }}
-                    >
-                        {datatype.enum.map((enumValue) => (<MenuItem value={enumValue.value} key={row.id + enumValue.name} >{enumValue.name}</MenuItem>))}
-                    </Select>
-                </FormControl>
-            </>)
-    }
-
-    if (datatype && datatype.typeName === "NcBoolean") {
-        const handleChange = () => {
-            if(isMethod){
-                if(isSequence) {
-                    DataProvider.changeSequenceParameter(oid, propertyId, index, parameterName, !value, structValue, valueHolder)
-                }else{
-                    DataProvider.changeParameter(oid, propertyId, parameterName, !value, structValue, valueHolder)
-                }
-            }
-            else {
-                if(isSequence) {
-                    DataProvider.changeSequencePropertyValue(oid, propertyId, index, !value, structValue, valueHolder)
-                }else{
-                    DataProvider.changeValue(oid, propertyId, !value, structValue, valueHolder)
-                }
-            }
-        };
-
-        return (
-            <>
-                {/* Checkbox: */}
-                <FormControl>
-                    <Checkbox
-                      checked={value}
-                      onChange={handleChange}
-                      inputProps={{ 'aria-label': 'controlled' }}
-                    />
-                </FormControl>
-            </>)
-    }
-
     return (
-        <>
-            {/* EDIT STRING: */}
-            {editable ?
-                <FormControl>
-                    <InputLabel htmlFor="defInput">{row.name}</InputLabel>
-                    <OutlinedInput
-                        id="defInput"
-                        sx={{ fontSize: '0.9rem', width: `${((newValue ? newValue.length : 5)/ 2.5) + 3}rem`, maxWidth: '14rem' }}
-                        label="User Label"
-                        size='small'
-                        autoFocus={true}
-                        error={newValue && (newValue === '' || newValue.length > 30)}
-                        onKeyDown={(key) => {
-                            if (key.code === "Enter" && newValue !== '' && newValue.length <= 30) {
-                                setEditable(!editable)
-                                if(isMethod){
-                                    if(isSequence) {
-                                        DataProvider.changeSequenceParameter(oid, propertyId, index, parameterName, newValue, structValue, valueHolder)
-                                    }else{
-                                        DataProvider.changeParameter(oid, propertyId, parameterName, newValue, structValue, valueHolder)
-                                    }
-                                }
-                                else {
-                                    if(isSequence) {
-                                        DataProvider.changeSequencePropertyValue(oid, propertyId, index, newValue, structValue, valueHolder)
-                                    }else{
-                                        DataProvider.changeValue(oid, propertyId, newValue, structValue, valueHolder)
-                                    }
-                                }
-                            }
-                        }}
-                        onChange={(e) => {
-                            setNewValue(e.target.value)
-                        }}
-                        value={newValue}
-                    />
-                </FormControl>
-                :
-                <span
-                    style={{ maxWidth: '5rem', overflowWrap: 'break-word' }}
-                    onDoubleClick={() => setEditable(!editable)}
-                >{value}</span>
-            }
-            {/* ICON NEXT TO STRING: */}
-            {editable ?
-                <IconButton
-                    aria-label='edit value'
-                    type='submit'
-                    onClick={() => {
-                        setEditable(!editable)
-                        if(isMethod){
-                            if(isSequence) {
-                                DataProvider.changeSequenceParameter(oid, propertyId, index, parameterName, newValue, structValue, valueHolder)
-                            }else{
-                                DataProvider.changeParameter(oid, propertyId, parameterName, newValue, structValue, valueHolder, newInvariantType)
-                            }
-                        }
-                        else {
-                            if(isSequence) {
-                                DataProvider.changeSequencePropertyValue(oid, propertyId, index, newValue, structValue, valueHolder)
-                            } else {
-                                DataProvider.changeValue(oid, propertyId, newValue, structValue, valueHolder)
-                            }
-                        }
-                    }}>
-                    {newValue && (newValue !== '' && newValue.length <= 30) ?
-                        <UploadIcon />
-                        :
-                        <></>
-                    }
-                </IconButton>
-                :
-                <IconButton
-                    aria-label='submit value'
-                    size='small'
-                    onClick={() => {
-                        setNewValue(value)
-                        setEditable(!editable)
-                    }}
-                ><EditIcon /></IconButton>
-            }
-            <span>{isMethod && datatype === undefined ? "Type Hint: " : ""}{isMethod && datatype === undefined ?
-                <Select
-                        labelId="type-hint-select-label"
-                        id="type-hint-select"
-                        sx={{ fontSize: '0.9rem', width: `9rem`, maxWidth: '14rem' }}
-                        size='small'
-                        value={invariantType}
-                        onChange={(e) => {
-                            setInvariantType(e.target.value)
-                            DataProvider.changeParameter(oid, propertyId, parameterName, newValue, structValue, valueHolder, e.target.value)
-                        }}
-                    >
-                        <MenuItem value="NcString" key={row.id + "string"} >String</MenuItem>
-                        <MenuItem value="NcInt64" key={row.id + "number"} >Number</MenuItem>
-                        <MenuItem value="NcBoolean" key={row.id + "bool"} >Boolean</MenuItem>
-                    </Select>
-
-                : ""}</span>
-        </>
-    )
+        <EditablePropertyControl
+            valueHolder={userLabel}
+            oid={oid}
+            propertyId={PROPERTY_IDS.OBJECT.USER_LABEL}
+        />
+    );
 }
 
 function ReadOnlyProperty(valueRow) {

--- a/is12-client/src/client/DataTables.js
+++ b/is12-client/src/client/DataTables.js
@@ -55,7 +55,10 @@ function addObjects(children, structure, state, tables) {
                 oid: node.oid,
                 name: node.role,
                 description: node.description,
-                userLabel: (state[`${node.oid}.${PROPERTY_IDS.OBJECT.USER_LABEL.level}.${PROPERTY_IDS.OBJECT.USER_LABEL.index}`] !== '' ? state[`${node.oid}.${PROPERTY_IDS.OBJECT.USER_LABEL.level}.${PROPERTY_IDS.OBJECT.USER_LABEL.index}`] : 'none'),
+                userLabel: (() => {
+                    const rawUserLabel = state[`${node.oid}.${PROPERTY_IDS.OBJECT.USER_LABEL.level}.${PROPERTY_IDS.OBJECT.USER_LABEL.index}`];
+                    return rawUserLabel != null && rawUserLabel !== '' ? rawUserLabel : 'none';
+                })(),
                 valueHolderMap: valueHolderMap,
                 children: node.children,
                 childNodes: [],
@@ -607,7 +610,11 @@ function UserLabelSection(props) {
     const { row } = props;
     const { oid } = props;
 
-    let userLabel = row["1.6"]
+    const userLabel = row["1.6"];
+
+    if (!userLabel) {
+        return <Typography variant="body2" color="grey.500">—</Typography>;
+    }
 
     return (
         <EditablePropertyControl
@@ -625,7 +632,7 @@ function ReadOnlyProperty(valueRow) {
     let datatype = valueHolder.datatype
     let value = valueHolder.value
 
-    if (value === null) {
+    if (value == null) {
             return (
             <>
             <p>NULL</p>

--- a/is12-client/src/client/EditablePropertyControl.jsx
+++ b/is12-client/src/client/EditablePropertyControl.jsx
@@ -27,7 +27,7 @@ const NUMERIC_TYPE_NAMES = new Set([
 
 function isValidSubmitValue(valueHolder, newValue) {
     if (valueHolder.name === 'userLabel') {
-        return newValue !== '' && newValue.length <= 30;
+        return newValue !== '' && (newValue?.length ?? 0) <= 30;
     }
 
     if (NUMERIC_TYPE_NAMES.has(valueHolder.datatype?.typeName)) {

--- a/is12-client/src/client/EditablePropertyControl.jsx
+++ b/is12-client/src/client/EditablePropertyControl.jsx
@@ -31,7 +31,7 @@ function isValidSubmitValue(valueHolder, newValue) {
     }
 
     if (NUMERIC_TYPE_NAMES.has(valueHolder.datatype?.typeName)) {
-        return newValue !== '' && !Number.isNaN(Number(newValue));
+        return newValue != null && newValue !== '' && !Number.isNaN(Number(newValue));
     }
 
     return newValue !== '';
@@ -75,8 +75,8 @@ export default function EditablePropertyControl({
     parameterName,
     compact = false,
 }) {
-    const datatype = valueHolder.datatype;
-    const value = valueHolder.value;
+    const datatype = valueHolder?.datatype;
+    const value = valueHolder?.value;
     const invariantType = undefined;
     const isNumericType = NUMERIC_TYPE_NAMES.has(datatype?.typeName);
 
@@ -85,6 +85,10 @@ export default function EditablePropertyControl({
     const [newInvariantType, setInvariantType] = useState(invariantType);
 
     const DataProvider = useContext(DataProviderContext);
+
+    if (!valueHolder) {
+        return null;
+    }
 
     const inputWidthSx = compact
         ? {
@@ -102,7 +106,8 @@ export default function EditablePropertyControl({
                     id="demo-simple-select"
                     sx={inputWidthSx}
                     size="small"
-                    value={value}
+                    displayEmpty
+                    value={value ?? ''}
                     onChange={(event) => {
                         setNewValue(event.target.value);
                         submitPropertyValue(

--- a/is12-client/src/client/EditablePropertyControl.jsx
+++ b/is12-client/src/client/EditablePropertyControl.jsx
@@ -1,0 +1,289 @@
+import { useContext, useState } from 'react';
+import UploadIcon from '@mui/icons-material/Backup';
+import EditIcon from '@mui/icons-material/Edit';
+import {
+    Box,
+    Checkbox,
+    FormControl,
+    IconButton,
+    InputLabel,
+    MenuItem,
+    OutlinedInput,
+    Select,
+} from '@mui/material';
+import { DataProviderContext } from './NCAController';
+import { NcDatatypeType } from '../global/Types';
+
+const NUMERIC_TYPE_NAMES = new Set([
+    'NcInt16',
+    'NcInt32',
+    'NcInt64',
+    'NcUint16',
+    'NcUint32',
+    'NcUint64',
+    'NcFloat32',
+    'NcFloat64',
+]);
+
+function isValidSubmitValue(valueHolder, newValue) {
+    if (valueHolder.name === 'userLabel') {
+        return newValue !== '' && newValue.length <= 30;
+    }
+
+    if (NUMERIC_TYPE_NAMES.has(valueHolder.datatype?.typeName)) {
+        return newValue !== '' && !Number.isNaN(Number(newValue));
+    }
+
+    return newValue !== '';
+}
+
+function submitPropertyValue(
+    DataProvider,
+    oid,
+    propertyId,
+    newValue,
+    valueHolder,
+    isMethod,
+    structValue,
+    index,
+    parameterName,
+    newInvariantType
+) {
+    if (isMethod) {
+        if (index !== undefined) {
+            DataProvider.changeSequenceParameter(oid, propertyId, index, parameterName, newValue, structValue, valueHolder);
+        } else {
+            DataProvider.changeParameter(oid, propertyId, parameterName, newValue, structValue, valueHolder, newInvariantType);
+        }
+        return;
+    }
+
+    if (index !== undefined) {
+        DataProvider.changeSequencePropertyValue(oid, propertyId, index, newValue, structValue, valueHolder);
+    } else {
+        DataProvider.changeValue(oid, propertyId, newValue, structValue, valueHolder);
+    }
+}
+
+export default function EditablePropertyControl({
+    valueHolder,
+    oid,
+    propertyId,
+    isMethod = false,
+    structValue,
+    index,
+    parameterName,
+    compact = false,
+}) {
+    const datatype = valueHolder.datatype;
+    const value = valueHolder.value;
+    const invariantType = undefined;
+    const isNumericType = NUMERIC_TYPE_NAMES.has(datatype?.typeName);
+
+    const [editable, setEditable] = useState(false);
+    const [newValue, setNewValue] = useState(value);
+    const [newInvariantType, setInvariantType] = useState(invariantType);
+
+    const DataProvider = useContext(DataProviderContext);
+
+    const inputWidthSx = compact
+        ? {
+            fontSize: '0.9rem',
+            width: `${((String(editable ? newValue : value ?? '').length || 5) / 2.5) + 3}rem`,
+            maxWidth: '20rem',
+        }
+        : { fontSize: '0.9rem', width: `${((newValue ? String(newValue).length : 5) / 2.5) + 3}rem`, maxWidth: '14rem' };
+
+    if (datatype && datatype.type === NcDatatypeType.NcEnum) {
+        return (
+            <FormControl fullWidth={compact}>
+                <Select
+                    labelId="demo-simple-select-label"
+                    id="demo-simple-select"
+                    sx={inputWidthSx}
+                    size="small"
+                    value={value}
+                    onChange={(event) => {
+                        setNewValue(event.target.value);
+                        submitPropertyValue(
+                            DataProvider,
+                            oid,
+                            propertyId,
+                            event.target.value,
+                            valueHolder,
+                            isMethod,
+                            structValue,
+                            index,
+                            parameterName,
+                            newInvariantType
+                        );
+                    }}
+                >
+                    {datatype.enum.map((enumValue) => (
+                        <MenuItem value={enumValue.value} key={`${valueHolder.name}-${enumValue.name}`}>
+                            {enumValue.name}
+                        </MenuItem>
+                    ))}
+                </Select>
+            </FormControl>
+        );
+    }
+
+    if (datatype && datatype.typeName === 'NcBoolean') {
+        const handleChange = () => {
+            submitPropertyValue(
+                DataProvider,
+                oid,
+                propertyId,
+                !value,
+                valueHolder,
+                isMethod,
+                structValue,
+                index,
+                parameterName,
+                newInvariantType
+            );
+        };
+
+        return (
+            <Box
+                sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    ...(compact ? { width: '100%', minHeight: '1.4375em' } : {}),
+                }}
+            >
+                <Checkbox
+                    size={compact ? 'small' : 'medium'}
+                    checked={Boolean(value)}
+                    onChange={handleChange}
+                    sx={compact ? { p: 0.25, ml: -0.25 } : undefined}
+                    inputProps={{ 'aria-label': valueHolder.name }}
+                />
+            </Box>
+        );
+    }
+
+    const canSubmit = isValidSubmitValue(valueHolder, newValue);
+    const inlineControlSx = {
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 0.5,
+        flexWrap: 'wrap',
+        maxWidth: '100%',
+    };
+
+    return (
+        <Box sx={inlineControlSx}>
+            {editable ? (
+                <FormControl>
+                    <InputLabel htmlFor={`editable-${oid}-${propertyId.level}-${propertyId.index}`}>
+                        {valueHolder.name}
+                    </InputLabel>
+                    <OutlinedInput
+                        id={`editable-${oid}-${propertyId.level}-${propertyId.index}`}
+                        sx={inputWidthSx}
+                        label={valueHolder.name}
+                        size="small"
+                        type={isNumericType ? 'number' : 'text'}
+                        autoFocus={true}
+                        error={Boolean(newValue) && !canSubmit}
+                        onKeyDown={(key) => {
+                            if (key.code === 'Enter' && canSubmit) {
+                                setEditable(false);
+                                submitPropertyValue(
+                                    DataProvider,
+                                    oid,
+                                    propertyId,
+                                    newValue,
+                                    valueHolder,
+                                    isMethod,
+                                    structValue,
+                                    index,
+                                    parameterName,
+                                    newInvariantType
+                                );
+                            }
+                        }}
+                        onChange={(event) => {
+                            setNewValue(event.target.value);
+                        }}
+                        value={newValue ?? ''}
+                    />
+                </FormControl>
+            ) : (
+                <span
+                    style={{
+                        maxWidth: compact ? undefined : '5rem',
+                        overflowWrap: 'break-word',
+                    }}
+                    onDoubleClick={() => setEditable(true)}
+                >
+                    {value ?? '—'}
+                </span>
+            )}
+            {editable ? (
+                <IconButton
+                    aria-label="save value"
+                    type="submit"
+                    size="small"
+                    onClick={() => {
+                        setEditable(false);
+                        if (canSubmit) {
+                            submitPropertyValue(
+                                DataProvider,
+                                oid,
+                                propertyId,
+                                newValue,
+                                valueHolder,
+                                isMethod,
+                                structValue,
+                                index,
+                                parameterName,
+                                newInvariantType
+                            );
+                        }
+                    }}
+                >
+                    {canSubmit ? <UploadIcon /> : null}
+                </IconButton>
+            ) : (
+                <IconButton
+                    aria-label="edit value"
+                    size="small"
+                    onClick={() => {
+                        setNewValue(value);
+                        setEditable(true);
+                    }}
+                >
+                    <EditIcon />
+                </IconButton>
+            )}
+            {isMethod && datatype === undefined ? (
+                <Select
+                    labelId="type-hint-select-label"
+                    id="type-hint-select"
+                    sx={{ fontSize: '0.9rem', width: '9rem', maxWidth: '14rem' }}
+                    size="small"
+                    value={invariantType}
+                    onChange={(event) => {
+                        setInvariantType(event.target.value);
+                        DataProvider.changeParameter(
+                            oid,
+                            propertyId,
+                            parameterName,
+                            newValue,
+                            structValue,
+                            valueHolder,
+                            event.target.value
+                        );
+                    }}
+                >
+                    <MenuItem value="NcString">String</MenuItem>
+                    <MenuItem value="NcInt64">Number</MenuItem>
+                    <MenuItem value="NcBoolean">Boolean</MenuItem>
+                </Select>
+            ) : null}
+        </Box>
+    );
+}

--- a/is12-client/src/client/EditablePropertyControl.jsx
+++ b/is12-client/src/client/EditablePropertyControl.jsx
@@ -25,13 +25,23 @@ const NUMERIC_TYPE_NAMES = new Set([
     'NcFloat64',
 ]);
 
-function isValidSubmitValue(valueHolder, newValue) {
+function isValidSubmitValue(valueHolder, newValue, isMethod = false) {
     if (valueHolder.name === 'userLabel') {
         return newValue !== '' && (newValue?.length ?? 0) <= 30;
     }
 
     if (NUMERIC_TYPE_NAMES.has(valueHolder.datatype?.typeName)) {
-        return newValue != null && newValue !== '' && !Number.isNaN(Number(newValue));
+        const numericValue = Number(newValue);
+
+        if (newValue == null || newValue === '' || Number.isNaN(numericValue)) {
+            return false;
+        }
+
+        if (isMethod && (valueHolder.name === 'index' || valueHolder.name === 'level')) {
+            return numericValue >= 1;
+        }
+
+        return true;
     }
 
     return newValue !== '';
@@ -169,7 +179,10 @@ export default function EditablePropertyControl({
         );
     }
 
-    const canSubmit = isValidSubmitValue(valueHolder, newValue);
+    const canSubmit = isValidSubmitValue(valueHolder, newValue, isMethod);
+    const hasMinimumOneConstraint =
+        isMethod && isNumericType && (valueHolder.name === 'index' || valueHolder.name === 'level');
+
     const inlineControlSx = {
         display: 'inline-flex',
         alignItems: 'center',
@@ -214,6 +227,7 @@ export default function EditablePropertyControl({
                             setNewValue(event.target.value);
                         }}
                         value={newValue ?? ''}
+                        inputProps={hasMinimumOneConstraint ? { min: 1 } : undefined}                        
                     />
                 </FormControl>
             ) : (

--- a/is12-client/src/client/statusMonitor/CollapsibleMonitorSection.jsx
+++ b/is12-client/src/client/statusMonitor/CollapsibleMonitorSection.jsx
@@ -1,0 +1,45 @@
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import {
+    Box,
+    Collapse,
+    Grid,
+    IconButton,
+    Typography,
+} from '@mui/material';
+
+export default function CollapsibleMonitorSection({ title, ariaLabel, children }) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <Box sx={{ mt: 1.5 }}>
+            <Box sx={{ display: 'flex', bgcolor: '#212a2f', alignItems: 'center' }}>
+                <Grid>
+                    <IconButton
+                        aria-label={ariaLabel}
+                        size="small"
+                        onClick={() => setOpen(!open)}
+                    >
+                        {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                    </IconButton>
+                </Grid>
+                <Grid>
+                    <Typography component="h4" variant="subtitle2" color="white" gutterBottom sx={{ mb: 0 }}>
+                        {title}
+                    </Typography>
+                </Grid>
+            </Box>
+            <Collapse in={open} timeout="auto" unmountOnExit>
+                {children}
+            </Collapse>
+        </Box>
+    );
+}
+
+CollapsibleMonitorSection.propTypes = {
+    title: PropTypes.string.isRequired,
+    ariaLabel: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired,
+};

--- a/is12-client/src/client/statusMonitor/DomainStatusChip.jsx
+++ b/is12-client/src/client/statusMonitor/DomainStatusChip.jsx
@@ -1,0 +1,72 @@
+import PropTypes from 'prop-types';
+import { Box, Typography } from '@mui/material';
+import StatusLight from './StatusLight';
+import TruncatedStatusMessage from './TruncatedStatusMessage';
+import {
+    formatStatusMessage,
+    getEnumLabel,
+    getTrafficLightColor,
+    getTransitionCounterValue,
+} from './statusMonitorUtils';
+
+export default function DomainStatusChip({ domain }) {
+    const statusLabel = getEnumLabel(domain.statusHolder);
+    const trafficLightColor = getTrafficLightColor(statusLabel);
+    const message = formatStatusMessage(domain.messageHolder);
+    const counterValue = getTransitionCounterValue(domain.counterHolder);
+
+    return (
+        <Box
+            sx={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 1,
+                minWidth: 160,
+                flex: '1 1 160px',
+                px: 1,
+                py: 0.75,
+                borderRadius: 1,
+                bgcolor: 'rgba(255, 255, 255, 0.04)',
+                border: '1px solid rgba(255, 255, 255, 0.08)',
+            }}
+        >
+            <StatusLight
+                color={trafficLightColor}
+                size="small"
+                label={`${domain.label}: ${statusLabel}`}
+            />
+            <Box sx={{ minWidth: 0, flex: 1 }}>
+                <Typography variant="caption" color="grey.300" sx={{ display: 'block', lineHeight: 1.2 }}>
+                    {domain.label}
+                </Typography>
+                <Typography variant="body2" color="white" sx={{ lineHeight: 1.2, wordBreak: 'break-word' }}>
+                    {statusLabel}
+                </Typography>
+                <TruncatedStatusMessage
+                    message={message}
+                    sx={{ mt: 0.25, lineHeight: 1.3 }}
+                />
+            </Box>
+            {counterValue !== null ? (
+                <Typography
+                    variant="caption"
+                    color="grey.400"
+                    sx={{ minWidth: '1.5rem', textAlign: 'right', pt: 0.25 }}
+                    title={`${domain.label} transition counter`}
+                >
+                    {counterValue}
+                </Typography>
+            ) : null}
+        </Box>
+    );
+}
+
+DomainStatusChip.propTypes = {
+    domain: PropTypes.shape({
+        key: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        statusHolder: PropTypes.object.isRequired,
+        messageHolder: PropTypes.object,
+        counterHolder: PropTypes.object,
+    }).isRequired,
+};

--- a/is12-client/src/client/statusMonitor/StatusLight.jsx
+++ b/is12-client/src/client/statusMonitor/StatusLight.jsx
@@ -1,0 +1,48 @@
+import PropTypes from 'prop-types';
+import { Box, Tooltip } from '@mui/material';
+
+const TRAFFIC_LIGHT_COLORS = {
+    green: '#2ecc71',
+    amber: '#f39c12',
+    red: '#e74c3c',
+    neutral: '#95a5a6',
+    unknown: '#7f8c8d',
+};
+
+export default function StatusLight({ color, size = 'medium', label, tooltip }) {
+    const diameter = size === 'large' ? 28 : size === 'small' ? 12 : 16;
+
+    const light = (
+        <Box
+            aria-label={label}
+            sx={{
+                width: diameter,
+                height: diameter,
+                minWidth: diameter,
+                borderRadius: '50%',
+                backgroundColor: TRAFFIC_LIGHT_COLORS[color] || TRAFFIC_LIGHT_COLORS.unknown,
+                border: '1px solid rgba(255, 255, 255, 0.35)',
+                boxShadow: color === 'neutral' || color === 'unknown'
+                    ? 'none'
+                    : `0 0 8px ${TRAFFIC_LIGHT_COLORS[color]}`,
+            }}
+        />
+    );
+
+    if (tooltip) {
+        return (
+            <Tooltip title={tooltip} arrow>
+                {light}
+            </Tooltip>
+        );
+    }
+
+    return light;
+}
+
+StatusLight.propTypes = {
+    color: PropTypes.oneOf(['green', 'amber', 'red', 'neutral', 'unknown']).isRequired,
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
+    label: PropTypes.string,
+    tooltip: PropTypes.string,
+};

--- a/is12-client/src/client/statusMonitor/StatusMonitorList.jsx
+++ b/is12-client/src/client/statusMonitor/StatusMonitorList.jsx
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types';
+import { Box } from '@mui/material';
+import StatusMonitorPanel from './StatusMonitorPanel';
+
+export default function StatusMonitorList({ monitors }) {
+    if (!monitors || monitors.length === 0) {
+        return null;
+    }
+
+    return (
+        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            {monitors.map((monitor) => (
+                <StatusMonitorPanel key={`${monitor.oid}-${monitor.name}`} row={monitor} />
+            ))}
+        </Box>
+    );
+}
+
+StatusMonitorList.propTypes = {
+    monitors: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/is12-client/src/client/statusMonitor/StatusMonitorMethodsPanel.jsx
+++ b/is12-client/src/client/statusMonitor/StatusMonitorMethodsPanel.jsx
@@ -1,0 +1,169 @@
+import PropTypes from 'prop-types';
+import { useContext, useMemo, useState } from 'react';
+import {
+    Box,
+    Button,
+    CircularProgress,
+    Typography,
+} from '@mui/material';
+import { DataProviderContext } from '../NCAController';
+import { NcMethodStatus } from '../../global/Types';
+import CollapsibleMonitorSection from './CollapsibleMonitorSection';
+import {
+    formatMethodLabel,
+    getStatusMonitorMethods,
+    parseCounterMethodResult,
+} from './statusMonitorUtils';
+
+function CounterResults({ counters }) {
+    if (!counters || counters.length === 0) {
+        return (
+            <Typography variant="caption" color="grey.500">
+                No counters reported
+            </Typography>
+        );
+    }
+
+    return (
+        <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 2 }}>
+            {counters.map((counter) => (
+                <Box key={counter.name} sx={{ minWidth: 80 }}>
+                    <Typography variant="caption" color="grey.400" sx={{ display: 'block' }}>
+                        {counter.name}
+                    </Typography>
+                    <Typography variant="body2" color="white">
+                        {counter.value}
+                    </Typography>
+                    {counter.description ? (
+                        <Typography variant="caption" color="grey.500" sx={{ display: 'block' }}>
+                            {counter.description}
+                        </Typography>
+                    ) : null}
+                </Box>
+            ))}
+        </Box>
+    );
+}
+
+CounterResults.propTypes = {
+    counters: PropTypes.arrayOf(PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+        description: PropTypes.string,
+    })).isRequired,
+};
+
+function MethodResultDisplay({ methodName, result }) {
+    if (!result) {
+        return null;
+    }
+
+    if (!result.success) {
+        return (
+            <Typography variant="caption" color="error.light" sx={{ display: 'block' }}>
+                {NcMethodStatus[result.status] || 'Error'}: {String(result.errorMessage ?? 'Method failed')}
+            </Typography>
+        );
+    }
+
+    if (methodName === 'ResetCountersAndMessages') {
+        return (
+            <Typography variant="caption" color="success.light" sx={{ display: 'block' }}>
+                Counters and status messages reset
+            </Typography>
+        );
+    }
+
+    return <CounterResults counters={parseCounterMethodResult(result.value)} />;
+}
+
+MethodResultDisplay.propTypes = {
+    methodName: PropTypes.string.isRequired,
+    result: PropTypes.shape({
+        success: PropTypes.bool.isRequired,
+        status: PropTypes.number,
+        value: PropTypes.any,
+        errorMessage: PropTypes.any,
+    }),
+};
+
+export default function StatusMonitorMethodsPanel({ row }) {
+    const DataProvider = useContext(DataProviderContext);
+    const [methodResults, setMethodResults] = useState({});
+    const [loadingMethodName, setLoadingMethodName] = useState(null);
+    const availableMethods = useMemo(() => getStatusMonitorMethods(row), [row]);
+
+    if (availableMethods.length === 0) {
+        return null;
+    }
+
+    const invokeStatusMonitorMethod = async (methodName, methodId) => {
+        setLoadingMethodName(methodName);
+
+        try {
+            const result = await DataProvider.invokeMethod(row.oid, methodId, { displayAlert: false });
+
+            setMethodResults((previousResults) => (
+                methodName === 'ResetCountersAndMessages' && result?.success
+                    ? { ResetCountersAndMessages: result }
+                    : { ...previousResults, [methodName]: result }
+            ));
+        } finally {
+            setLoadingMethodName(null);
+        }
+    };
+
+    return (
+        <CollapsibleMonitorSection title="Methods" ariaLabel="expand methods">
+            <Box sx={{ pt: 1, pb: 0.5 }}>
+                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                    {availableMethods.map(({ methodKey, descriptor, methodId }) => (
+                        <Button
+                            key={methodKey}
+                            variant="outlined"
+                            size="small"
+                            disabled={loadingMethodName !== null}
+                            onClick={() => invokeStatusMonitorMethod(descriptor.name, methodId)}
+                            sx={{ textTransform: 'none' }}
+                        >
+                            {loadingMethodName === descriptor.name ? (
+                                <CircularProgress size={16} sx={{ mr: 1, color: 'inherit' }} />
+                            ) : null}
+                            {formatMethodLabel(descriptor.name, descriptor.description)}
+                        </Button>
+                    ))}
+                </Box>
+
+                {availableMethods.map(({ descriptor }) => {
+                    const result = methodResults[descriptor.name];
+                    if (!result) {
+                        return null;
+                    }
+
+                    return (
+                        <Box
+                            key={descriptor.name}
+                            sx={{
+                                mt: 1,
+                                px: 1,
+                                py: 0.75,
+                                borderRadius: 1,
+                                bgcolor: 'rgba(255, 255, 255, 0.03)',
+                                border: '1px solid rgba(255, 255, 255, 0.06)',
+                            }}
+                        >
+                            <Typography variant="caption" color="grey.400" sx={{ display: 'block', mb: 0.5 }}>
+                                {formatMethodLabel(descriptor.name, descriptor.description)}
+                            </Typography>
+                            <MethodResultDisplay methodName={descriptor.name} result={result} />
+                        </Box>
+                    );
+                })}
+            </Box>
+        </CollapsibleMonitorSection>
+    );
+}
+
+StatusMonitorMethodsPanel.propTypes = {
+    row: PropTypes.object.isRequired,
+};

--- a/is12-client/src/client/statusMonitor/StatusMonitorPanel.jsx
+++ b/is12-client/src/client/statusMonitor/StatusMonitorPanel.jsx
@@ -1,0 +1,113 @@
+import PropTypes from 'prop-types';
+import { useState } from 'react';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import {
+    Box,
+    Collapse,
+    IconButton,
+    Typography,
+} from '@mui/material';
+import StatusLight from './StatusLight';
+import DomainStatusChip from './DomainStatusChip';
+import StatusMonitorMethodsPanel from './StatusMonitorMethodsPanel';
+import StatusMonitorSettingsGrid from './StatusMonitorSettingsGrid';
+import TruncatedStatusMessage from './TruncatedStatusMessage';
+import {
+    buildStatusMonitorViewModel,
+    getMonitorDisplayName,
+    getOverallStatusPresentation,
+} from './statusMonitorUtils';
+
+export default function StatusMonitorPanel({ row }) {
+    const [expanded, setExpanded] = useState(false);
+    const viewModel = buildStatusMonitorViewModel(row);
+    const { label: overallLabel, color: overallColor, message: overallMessage } = getOverallStatusPresentation(viewModel);
+
+    return (
+        <Box
+            sx={{
+                borderBottom: '1px solid rgba(255, 255, 255, 0.08)',
+                bgcolor: '#1a2328',
+            }}
+        >
+            <Box
+                sx={{
+                    display: 'grid',
+                    gridTemplateColumns: 'auto auto minmax(0, 1fr) 8.5rem minmax(8rem, 1.5fr)',
+                    alignItems: 'center',
+                    gap: 1.5,
+                    px: 1,
+                    py: 1,
+                    cursor: 'pointer',
+                }}
+                onClick={() => setExpanded(!expanded)}
+            >
+                <IconButton
+                    aria-label={expanded ? 'collapse monitor' : 'expand monitor'}
+                    size="small"
+                    onClick={(event) => {
+                        event.stopPropagation();
+                        setExpanded(!expanded);
+                    }}
+                >
+                    {expanded ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+                </IconButton>
+
+                <StatusLight
+                    color={overallColor}
+                    size="large"
+                    label={`Overall status: ${overallLabel}`}
+                />
+
+                <Box sx={{ minWidth: 0 }}>
+                    <Typography variant="subtitle2" color="white" sx={{ lineHeight: 1.2 }}>
+                        {getMonitorDisplayName(row)}
+                    </Typography>
+                    <Typography variant="caption" color="grey.400" sx={{ lineHeight: 1.2 }}>
+                        {row.description || row.name}
+                    </Typography>
+                </Box>
+
+                <Typography
+                    variant="body2"
+                    color="grey.300"
+                    sx={{
+                        textAlign: 'right',
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                    }}
+                >
+                    {overallLabel}
+                </Typography>
+
+                <TruncatedStatusMessage
+                    message={overallMessage}
+                    sx={{ textAlign: 'right', lineHeight: 1.3 }}
+                />
+            </Box>
+
+            <Collapse in={expanded} timeout="auto" unmountOnExit>
+                <Box sx={{ px: 2, pb: 1.5, pt: 0.5 }}>
+                    <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                        {viewModel.domains.map((domain) => (
+                            <DomainStatusChip key={domain.key} domain={domain} />
+                        ))}
+                    </Box>
+
+                    <StatusMonitorSettingsGrid
+                        settingsProperties={viewModel.settingsProperties}
+                        oid={row.oid}
+                    />
+
+                    <StatusMonitorMethodsPanel row={row} />
+                </Box>
+            </Collapse>
+        </Box>
+    );
+}
+
+StatusMonitorPanel.propTypes = {
+    row: PropTypes.object.isRequired,
+};

--- a/is12-client/src/client/statusMonitor/StatusMonitorSettingsGrid.jsx
+++ b/is12-client/src/client/statusMonitor/StatusMonitorSettingsGrid.jsx
@@ -1,0 +1,109 @@
+import PropTypes from 'prop-types';
+import { Box, Typography } from '@mui/material';
+import EditablePropertyControl from '../EditablePropertyControl';
+import CollapsibleMonitorSection from './CollapsibleMonitorSection';
+import { elementIdFromKey, getEnumLabel } from './statusMonitorUtils';
+import { NcDatatypeType } from '../../global/Types';
+
+const EDITABLE_SETTING_NAMES = new Set(['userLabel', 'statusReportingDelay']);
+
+function ReadOnlySettingValue({ valueHolder }) {
+    if (valueHolder.value === null || valueHolder.value === undefined || valueHolder.value === '') {
+        return (
+            <Typography variant="body2" color="grey.500">
+                —
+            </Typography>
+        );
+    }
+
+    const displayValue = valueHolder.datatype?.type === NcDatatypeType.NcEnum
+        ? getEnumLabel(valueHolder)
+        : String(valueHolder.value);
+
+    return (
+        <Typography variant="body2" color="white" sx={{ wordBreak: 'break-word' }}>
+            {displayValue}
+        </Typography>
+    );
+}
+
+ReadOnlySettingValue.propTypes = {
+    valueHolder: PropTypes.object.isRequired,
+};
+
+function SettingsValue({ propKey, valueHolder, oid }) {
+    const usesEditableControl = !valueHolder.isReadOnly && (
+        EDITABLE_SETTING_NAMES.has(valueHolder.name)
+        || valueHolder.datatype?.typeName === 'NcBoolean'
+    );
+
+    if (usesEditableControl) {
+        return (
+            <EditablePropertyControl
+                valueHolder={valueHolder}
+                oid={oid}
+                propertyId={elementIdFromKey(propKey)}
+                compact
+            />
+        );
+    }
+
+    return <ReadOnlySettingValue valueHolder={valueHolder} />;
+}
+
+SettingsValue.propTypes = {
+    propKey: PropTypes.string.isRequired,
+    valueHolder: PropTypes.object.isRequired,
+    oid: PropTypes.number.isRequired,
+};
+
+export default function StatusMonitorSettingsGrid({ settingsProperties, oid }) {
+    if (!settingsProperties || settingsProperties.length === 0) {
+        return null;
+    }
+
+    return (
+        <CollapsibleMonitorSection title="Settings" ariaLabel="expand settings">
+            <Box
+                sx={{
+                    pt: 1,
+                    pb: 0.5,
+                    px: 1,
+                    borderRadius: 1,
+                    bgcolor: 'rgba(255, 255, 255, 0.03)',
+                    border: '1px solid rgba(255, 255, 255, 0.06)',
+                }}
+            >
+                <Box
+                    sx={{
+                        display: 'grid',
+                        gridTemplateColumns: { xs: '1fr', sm: 'minmax(10rem, 14rem) minmax(0, 1fr)' },
+                        columnGap: 2,
+                        rowGap: 1.25,
+                        alignItems: 'center',
+                    }}
+                >
+                    {settingsProperties.map(({ propKey, valueHolder, label }) => (
+                        <Box key={propKey} sx={{ display: 'contents' }}>
+                            <Typography variant="caption" color="grey.400" sx={{ alignSelf: 'center' }}>
+                                {label}
+                            </Typography>
+                            <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', minHeight: '1.4375em' }}>
+                                <SettingsValue propKey={propKey} valueHolder={valueHolder} oid={oid} />
+                            </Box>
+                        </Box>
+                    ))}
+                </Box>
+            </Box>
+        </CollapsibleMonitorSection>
+    );
+}
+
+StatusMonitorSettingsGrid.propTypes = {
+    settingsProperties: PropTypes.arrayOf(PropTypes.shape({
+        propKey: PropTypes.string.isRequired,
+        valueHolder: PropTypes.object.isRequired,
+        label: PropTypes.string.isRequired,
+    })).isRequired,
+    oid: PropTypes.number.isRequired,
+};

--- a/is12-client/src/client/statusMonitor/StatusMonitorTabSummary.jsx
+++ b/is12-client/src/client/statusMonitor/StatusMonitorTabSummary.jsx
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types';
+import { Box, Typography } from '@mui/material';
+import StatusLight from './StatusLight';
+import {
+    buildStatusMonitorViewModel,
+    formatStatusMessage,
+    getMonitorDisplayName,
+    getOverallStatusPresentation,
+} from './statusMonitorUtils';
+
+export default function StatusMonitorTabSummary({ monitors }) {
+    return monitors.map((monitor) => {
+        const viewModel = buildStatusMonitorViewModel(monitor);
+        const { label, color } = getOverallStatusPresentation(viewModel);
+        const monitorLabel = getMonitorDisplayName(monitor);
+
+        return (
+            <Box
+                key={`${monitor.oid}-${monitor.name}`}
+                sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}
+            >
+                <StatusLight
+                    color={color}
+                    size="small"
+                    label={`${monitorLabel}: ${label}`}
+                    tooltip={formatStatusMessage(viewModel.overallStatusMessage) || undefined}
+                />
+                <Typography variant="caption" color="grey.300">
+                    {monitorLabel}
+                </Typography>
+            </Box>
+        );
+    });
+}
+
+StatusMonitorTabSummary.propTypes = {
+    monitors: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/is12-client/src/client/statusMonitor/TruncatedStatusMessage.jsx
+++ b/is12-client/src/client/statusMonitor/TruncatedStatusMessage.jsx
@@ -1,0 +1,70 @@
+import PropTypes from 'prop-types';
+import { Box, Tooltip, Typography } from '@mui/material';
+
+const MESSAGE_LINE_HEIGHT = '1.3em';
+
+const ellipsisStyles = {
+    display: 'block',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    minWidth: 0,
+};
+
+export default function TruncatedStatusMessage({
+    message,
+    variant = 'caption',
+    color = 'grey.400',
+    sx = {},
+    placeholder = true,
+}) {
+    const hasMessage = message !== null && message !== undefined && message !== '';
+
+    const reservedSpaceStyles = placeholder ? { minHeight: MESSAGE_LINE_HEIGHT } : {};
+
+    if (!hasMessage) {
+        if (!placeholder) {
+            return null;
+        }
+
+        return (
+            <Typography
+                variant={variant}
+                aria-hidden="true"
+                sx={{
+                    ...ellipsisStyles,
+                    ...reservedSpaceStyles,
+                    ...sx,
+                }}
+            >
+                {'\u00a0'}
+            </Typography>
+        );
+    }
+
+    const messageText = (
+        <Typography
+            variant={variant}
+            color={color}
+            sx={{ ...ellipsisStyles, ...reservedSpaceStyles, ...sx }}
+        >
+            {message}
+        </Typography>
+    );
+
+    return (
+        <Tooltip title={message} arrow placement="top">
+            <Box sx={{ minWidth: 0, maxWidth: '100%' }}>
+                {messageText}
+            </Box>
+        </Tooltip>
+    );
+}
+
+TruncatedStatusMessage.propTypes = {
+    message: PropTypes.string,
+    variant: PropTypes.string,
+    color: PropTypes.string,
+    sx: PropTypes.object,
+    placeholder: PropTypes.bool,
+};

--- a/is12-client/src/client/statusMonitor/statusMonitorRegistry.js
+++ b/is12-client/src/client/statusMonitor/statusMonitorRegistry.js
@@ -1,0 +1,40 @@
+/**
+ * Known BCP-008 status monitor class identifiers and domain ordering.
+ */
+
+export const STATUS_MONITOR_REGISTRY = {
+    '1.2.2.1': {
+        kind: 'receiver',
+        domainOrder: ['link', 'connection', 'externalSynchronization', 'stream'],
+    },
+    '1.2.2.2': {
+        kind: 'sender',
+        domainOrder: ['link', 'transmission', 'externalSynchronization', 'essence'],
+    },
+};
+
+export const STATUS_MONITOR_METHOD_NAMES = [
+    'GetLostPacketCounters',
+    'GetLatePacketCounters',
+    'ResetCountersAndMessages',
+];
+
+export const STATUS_MONITOR_METHOD_LABELS = {
+    GetLostPacketCounters: 'Lost packet counters',
+    GetLatePacketCounters: 'Late packet counters',
+    ResetCountersAndMessages: 'Reset counters & messages',
+};
+
+export const STATUS_MONITOR_SETTINGS = {
+    userLabel: 'User label',
+    statusReportingDelay: 'Status reporting delay (s)',
+    autoResetCountersAndMessages: 'Auto reset counters & messages',
+    synchronizationSourceId: 'Synchronization source ID',
+};
+
+export const STATUS_MONITOR_SETTINGS_ORDER = [
+    'userLabel',
+    'statusReportingDelay',
+    'autoResetCountersAndMessages',
+    'synchronizationSourceId',
+];

--- a/is12-client/src/client/statusMonitor/statusMonitorUtils.js
+++ b/is12-client/src/client/statusMonitor/statusMonitorUtils.js
@@ -1,0 +1,270 @@
+import { NcDatatypeType } from '../../global/Types';
+import { STATUS_MONITOR_REGISTRY, STATUS_MONITOR_METHOD_NAMES, STATUS_MONITOR_METHOD_LABELS, STATUS_MONITOR_SETTINGS, STATUS_MONITOR_SETTINGS_ORDER } from './statusMonitorRegistry';
+
+const NC_STATUS_MONITOR_CLASS_PREFIX = [1, 2, 2];
+
+export function isStatusMonitor(classId) {
+    if (!classId || classId.length < NC_STATUS_MONITOR_CLASS_PREFIX.length) {
+        return false;
+    }
+
+    return NC_STATUS_MONITOR_CLASS_PREFIX.every(
+        (segment, index) => classId[index] === segment
+    );
+}
+
+export function subtreeContainsStatusMonitor(row) {
+    if (isStatusMonitor(row.classId)) {
+        return true;
+    }
+
+    return row.childNodes.some((child) => subtreeContainsStatusMonitor(child));
+}
+
+export function elementIdFromKey(propKey) {
+    const [level, index] = propKey.split('.');
+    return {
+        level: Number(level),
+        index: Number(index),
+    };
+}
+
+export function getMonitorDisplayName(row) {
+    return row.userLabel && row.userLabel !== 'none' ? row.userLabel : row.name;
+}
+
+export function getOverallStatusPresentation(viewModel) {
+    const label = viewModel.overallStatus ? getEnumLabel(viewModel.overallStatus) : 'Unknown';
+
+    return {
+        label,
+        color: getTrafficLightColor(label),
+        message: formatStatusMessage(viewModel.overallStatusMessage),
+    };
+}
+
+export function formatMethodLabel(methodName, description) {
+    return STATUS_MONITOR_METHOD_LABELS[methodName] || description || methodName;
+}
+
+export function getTransitionCounterValue(counterHolder) {
+    if (counterHolder?.value === null || counterHolder?.value === undefined) {
+        return null;
+    }
+
+    return Number(counterHolder.value);
+}
+
+export function getStatusMonitorNodes(row) {
+    if (isStatusMonitor(row.classId)) {
+        return [row];
+    }
+
+    const monitors = [];
+
+    row.childNodes.forEach((child) => {
+        monitors.push(...getStatusMonitorNodes(child));
+    });
+
+    return monitors;
+}
+
+function blockOnlyContainsStatusMonitors(row) {
+    if (isStatusMonitor(row.classId) || !subtreeContainsStatusMonitor(row)) {
+        return false;
+    }
+
+    const hasProperties = row.valueHolderMap && Object.keys(row.valueHolderMap).length > 0;
+    const hasMethods = row.methods && Object.keys(row.methods).length > 0;
+    const hasOtherChildren = row.childNodes.some((child) => {
+        return !isStatusMonitor(child.classId) && !blockOnlyContainsStatusMonitors(child);
+    });
+
+    return !hasProperties && !hasMethods && !hasOtherChildren;
+}
+
+export function getNonStatusMonitorChildNodes(row) {
+    return row.childNodes.filter((child) => {
+        return !isStatusMonitor(child.classId) && !blockOnlyContainsStatusMonitors(child);
+    });
+}
+
+export function getEnumLabel(valueHolder) {
+    if (!valueHolder || valueHolder.value === null || valueHolder.value === undefined) {
+        return 'Unknown';
+    }
+
+    const { value, datatype } = valueHolder;
+
+    if (!datatype || datatype.type !== NcDatatypeType.NcEnum || !datatype.enum) {
+        return String(value);
+    }
+
+    const match = datatype.enum.find((enumItem) => enumItem.value === value);
+    return match ? match.name : String(value);
+}
+
+export function getTrafficLightColor(enumLabel) {
+    switch (enumLabel) {
+        case 'Healthy':
+        case 'AllUp':
+            return 'green';
+        case 'PartiallyHealthy':
+        case 'SomeDown':
+            return 'amber';
+        case 'Unhealthy':
+        case 'AllDown':
+            return 'red';
+        case 'Inactive':
+        case 'NotUsed':
+            return 'neutral';
+        default:
+            return 'unknown';
+    }
+}
+
+export function formatDomainLabel(domainKey) {
+    const withSpaces = domainKey.replace(/([A-Z])/g, ' $1').trim();
+    return withSpaces.charAt(0).toUpperCase() + withSpaces.slice(1);
+}
+
+export function formatStatusMessage(messageHolder) {
+    const messageValue = messageHolder?.value;
+
+    if (messageValue === null || messageValue === undefined || messageValue === '') {
+        return null;
+    }
+
+    return String(messageValue);
+}
+
+function indexByPropertyName(valueHolderMap) {
+    const byName = {};
+
+    Object.entries(valueHolderMap).forEach(([propKey, valueHolder]) => {
+        if (valueHolder?.name) {
+            byName[valueHolder.name] = { propKey, valueHolder };
+        }
+    });
+
+    return byName;
+}
+
+function sortDomains(domains, classId) {
+    const classKey = classId.join('.');
+    const domainOrder = STATUS_MONITOR_REGISTRY[classKey]?.domainOrder;
+
+    if (!domainOrder) {
+        return [...domains].sort((left, right) => left.key.localeCompare(right.key));
+    }
+
+    return [...domains].sort((left, right) => {
+        const leftIndex = domainOrder.indexOf(left.key);
+        const rightIndex = domainOrder.indexOf(right.key);
+
+        if (leftIndex === -1 && rightIndex === -1) {
+            return left.key.localeCompare(right.key);
+        }
+        if (leftIndex === -1) {
+            return 1;
+        }
+        if (rightIndex === -1) {
+            return -1;
+        }
+        return leftIndex - rightIndex;
+    });
+}
+
+export function buildStatusMonitorViewModel(row) {
+    const valueHolderMap = row.valueHolderMap || {};
+    const byName = indexByPropertyName(valueHolderMap);
+
+    const overallStatus = byName.overallStatus?.valueHolder;
+    const overallStatusMessage = byName.overallStatusMessage?.valueHolder;
+
+    const domains = [];
+
+    Object.values(byName).forEach(({ valueHolder }) => {
+        const propertyName = valueHolder.name;
+
+        if (!propertyName?.endsWith('Status') || propertyName === 'overallStatus') {
+            return;
+        }
+
+        if (valueHolder.datatype?.type !== NcDatatypeType.NcEnum) {
+            return;
+        }
+
+        const domainKey = propertyName.slice(0, -'Status'.length);
+        const messageHolder = byName[`${domainKey}StatusMessage`]?.valueHolder;
+        const counterHolder = byName[`${domainKey}StatusTransitionCounter`]?.valueHolder;
+
+        domains.push({
+            key: domainKey,
+            label: formatDomainLabel(domainKey),
+            statusHolder: valueHolder,
+            messageHolder,
+            counterHolder,
+        });
+    });
+
+    return {
+        overallStatus,
+        overallStatusMessage,
+        domains: sortDomains(domains, row.classId),
+        settingsProperties: getSettingsProperties(valueHolderMap),
+    };
+}
+
+export function getSettingsProperties(valueHolderMap) {
+    const propertiesByName = {};
+
+    Object.entries(valueHolderMap).forEach(([propKey, valueHolder]) => {
+        if (valueHolder?.name && STATUS_MONITOR_SETTINGS[valueHolder.name]) {
+            propertiesByName[valueHolder.name] = {
+                propKey,
+                valueHolder,
+                label: STATUS_MONITOR_SETTINGS[valueHolder.name],
+            };
+        }
+    });
+
+    return STATUS_MONITOR_SETTINGS_ORDER
+        .filter((propertyName) => propertiesByName[propertyName])
+        .map((propertyName) => propertiesByName[propertyName]);
+}
+
+export function getStatusMonitorMethods(row) {
+    if (!row.methods) {
+        return [];
+    }
+
+    const allowedMethodNames = new Set(STATUS_MONITOR_METHOD_NAMES);
+
+    return Object.entries(row.methods)
+        .map(([methodKey, method]) => ({
+            methodKey,
+            descriptor: method.Descriptor,
+            methodId: elementIdFromKey(methodKey),
+        }))
+        .filter(({ descriptor }) => allowedMethodNames.has(descriptor.name))
+        .sort((left, right) => {
+            const leftIndex = STATUS_MONITOR_METHOD_NAMES.indexOf(left.descriptor.name);
+            const rightIndex = STATUS_MONITOR_METHOD_NAMES.indexOf(right.descriptor.name);
+            return leftIndex - rightIndex;
+        });
+}
+
+export function parseCounterMethodResult(value) {
+    if (!value) {
+        return [];
+    }
+
+    const counterList = Array.isArray(value) ? value : [value];
+
+    return counterList.map((counter, index) => ({
+        name: counter?.name ?? counter?.Name ?? `Counter ${index + 1}`,
+        value: counter?.value ?? counter?.Value ?? 0,
+        description: counter?.description ?? counter?.Description,
+    }));
+}

--- a/is12-client/src/middleware/DataProvider.ts
+++ b/is12-client/src/middleware/DataProvider.ts
@@ -111,7 +111,7 @@ export default class DataProvider {
             var valueHolder = this.propertyMap[prop.oid].ValueHolderMap![propId] as any
             valueHolder = this.updateProperty(valueHolder, newValue, prop.eventData.sequenceItemIndex)
             this.propertyMap[prop.oid].ValueHolderMap![propId] = valueHolder
-            this.propertyMap[prop.oid].State![propId](valueHolder)
+            this.propertyMap[prop.oid].State![propId](valueHolder.value)
         })
     }
 
@@ -432,7 +432,12 @@ export default class DataProvider {
         return this.castValue(typeName, valueHolder.value)
     }
 
-    public invokeMethod = async (oid: number, methodId: NcElementId) => {
+    public invokeMethod = async (
+        oid: number,
+        methodId: NcElementId,
+        options?: { displayAlert?: boolean }
+    ) => {
+        const displayAlert = options?.displayAlert !== false;
 
         var method_args = {} as GenericMap
 
@@ -453,20 +458,50 @@ export default class DataProvider {
 
         if (typeof result === 'object' && 'status' in result) {
             if (result.status === NcMethodStatus.OK) {
-                var message = result.value ? JSON.stringify(result.value) : 'OK'
-                alert(message)
+                if (displayAlert) {
+                    var message = result.value ? JSON.stringify(result.value) : 'OK'
+                    alert(message)
+                }
+
+                return {
+                    success: true,
+                    status: result.status,
+                    value: result.value,
+                }
             }
             else if (result.status === NcMethodStatus.MethodDeprecated){
-                alert('Method deprecated: ' + JSON.stringify(result.value))
+                if (displayAlert) {
+                    alert('Method deprecated: ' + JSON.stringify(result.value))
+                }
+
+                return {
+                    success: true,
+                    status: result.status,
+                    value: result.value,
+                }
             }
             else{
-                // error
-                alert(NcMethodStatus[result.status] + ': ' + result.errorMessage)
+                if (displayAlert) {
+                    alert(NcMethodStatus[result.status] + ': ' + result.errorMessage)
+                }
+
+                return {
+                    success: false,
+                    status: result.status,
+                    errorMessage: result.errorMessage,
+                }
             }
         }
         else {
-            // Some sort of error has occurred
-            alert('ERROR! ' + result)
+            if (displayAlert) {
+                alert('ERROR! ' + result)
+            }
+
+            return {
+                success: false,
+                status: NcMethodStatus.DeviceError,
+                errorMessage: result,
+            };
         }
     }
 }


### PR DESCRIPTION
- Visualizes the Sender and Receiver monitor panels status information
- A more compact representation than the raw object

Collapsed monitor blocks give status overview of contained monitors in header bar:
<img width="894" height="103" alt="image" src="https://github.com/user-attachments/assets/e699a913-d7f8-40f2-8ac4-b16b09305a58" />
Expanded blocks show overall status of contained monitors:
<img width="880" height="830" alt="image" src="https://github.com/user-attachments/assets/de787996-05c5-4c32-aa0d-6a6dda3fce63" />
Individual monitor panel can be expanded to see domain statuses:
<img width="872" height="243" alt="image" src="https://github.com/user-attachments/assets/0ab1d9b5-3898-482e-a15c-1808575ad73d" />
Settings and methods panels can be expanded within monitor:
<img width="873" height="509" alt="image" src="https://github.com/user-attachments/assets/9e779f52-03f8-41b2-9ee3-09bb52aa6660" />
