### PR TITLE
Fix index parameter minimum bug

### DIFF
--- a/is12-client/src/backend/BlockNodeCommands.ts
+++ b/is12-client/src/backend/BlockNodeCommands.ts
@@ -250,17 +250,20 @@ export const getDatatypes = async (NCASocket: NCAConnection): Promise<NCDatatype
             let datatype = descriptor as NcDatatypeDescriptorStruct;
 
             var name = datatype.name
+            var baseTypeName = datatype.name
             var fields = datatype.fields.slice()
 
             // add inherited fields
             while (datatype.parentType !== null) {
                 datatype = descriptorMap[datatype.parentType]
+                baseTypeName = datatype.name
                 fields = fields.concat(datatype.fields)
             }
 
             result[name] = {
                 type: NcDatatypeType.NcStruct,
                 typeName: descriptor.name,
+                baseTypeName: baseTypeName,
                 enum: null,
                 fields: fields,
                 sequenceType: false

--- a/is12-client/src/client/DataTables.js
+++ b/is12-client/src/client/DataTables.js
@@ -429,7 +429,7 @@ function PropsTable(valueRow) {
 
 function PropertyRow(valueRow) {
     const { row } = valueRow;
-    const { structValue } = valueRow // used if this property is part of a struct. Undefined otherwise.
+    const { parentValueHolder } = valueRow // used if this property is part of a struct. Undefined otherwise.
     const { isMethod } = valueRow
     const { parameterName } = valueRow
     const { index } = valueRow // used if this property is part of a struct which is part of a sequence. Undefined otherwise.
@@ -438,7 +438,7 @@ function PropertyRow(valueRow) {
     return(<>
         <TableRow>
         <TableCell sx={{ width: "15%", paddingLeft: 2 }}>{row.name}</TableCell>
-        <TableCell sx={{ width: '45%' }}>{isReadOnly(row.valueHolder) ? <ReadOnlyProperty row={row} /> : <EditableProperty row={row} structValue={structValue} index={index} isMethod={isMethod} parameterName={parameterName}/>}</TableCell>
+        <TableCell sx={{ width: '45%' }}>{isReadOnly(row.valueHolder) ? <ReadOnlyProperty row={row} /> : <EditableProperty row={row} parentValueHolder={parentValueHolder} index={index} isMethod={isMethod} parameterName={parameterName}/>}</TableCell>
         {showDescription ? <TableCell>{row.description}</TableCell> :<></>}
         </TableRow>
         </>)
@@ -508,7 +508,7 @@ function StructProperty(valueRow) {
                     </TableHead>
                     <TableBody>
                         {values_map.map((value) => (
-                            Array.isArray(value.valueHolder.values) ? <SequenceProperty key={value.key} row={value} index={index} isMethod={isMethod} parameterName={parameterName}/> : isStructDatatype(value.valueHolder) ? <StructProperty key={value.key} row={value} index={index} isMethod={isMethod} parameterName={parameterName}/> : <PropertyRow key={value.key} row={value} structValue={valueMap} index={index} showDescription={true} isMethod={isMethod} parameterName={parameterName}/>
+                            Array.isArray(value.valueHolder.values) ? <SequenceProperty key={value.key} row={value} index={index} isMethod={isMethod} parameterName={parameterName}/> : isStructDatatype(value.valueHolder) ? <StructProperty key={value.key} row={value} index={index} isMethod={isMethod} parameterName={parameterName}/> : <PropertyRow key={value.key} row={value} parentValueHolder={row.valueHolder} index={index} showDescription={true} isMethod={isMethod} parameterName={parameterName}/>
                         ))}
                     </TableBody>
                 </Table>
@@ -581,7 +581,7 @@ function EditableProperty(valueRow) {
     const { row } = valueRow;
     const { isMethod } = valueRow
     const { parameterName } = valueRow
-    const { structValue } = valueRow
+    const { parentValueHolder } = valueRow
     const { index } = valueRow
 
     let formattedId = row.id.split('.')
@@ -596,7 +596,7 @@ function EditableProperty(valueRow) {
             oid={row.oid}
             propertyId={propertyId}
             isMethod={isMethod}
-            structValue={structValue}
+            parentValueHolder={parentValueHolder}
             index={index}
             parameterName={parameterName}
         />

--- a/is12-client/src/client/EditablePropertyControl.jsx
+++ b/is12-client/src/client/EditablePropertyControl.jsx
@@ -185,8 +185,6 @@ export default function EditablePropertyControl({
     // parameter that happens to be named that way
     const isElementIdField =
         isMethod &&
-        isNumericType &&
-        (valueHolder.name === 'index' || valueHolder.name === 'level') &&
         isElementIdDatatype(parentValueHolder?.datatype);
 
     const canSubmit = isValidSubmitValue(valueHolder, newValue, isElementIdField);

--- a/is12-client/src/client/EditablePropertyControl.jsx
+++ b/is12-client/src/client/EditablePropertyControl.jsx
@@ -183,12 +183,13 @@ export default function EditablePropertyControl({
 
     // level and index are only 1-based when they belong to an ID, not for any
     // parameter that happens to be named that way
-    const isElementIdField =
+    const enforceMinimumOne =
         isMethod &&
+        (valueHolder.name === 'index' || valueHolder.name === 'level') &&
         isElementIdDatatype(parentValueHolder?.datatype);
 
-    const canSubmit = isValidSubmitValue(valueHolder, newValue, isElementIdField);
-    const hasMinimumOneConstraint = isElementIdField;
+    const canSubmit = isValidSubmitValue(valueHolder, newValue, enforceMinimumOne);
+    const hasMinimumOneConstraint = enforceMinimumOne;
 
     const inlineControlSx = {
         display: 'inline-flex',

--- a/is12-client/src/client/EditablePropertyControl.jsx
+++ b/is12-client/src/client/EditablePropertyControl.jsx
@@ -13,6 +13,7 @@ import {
 } from '@mui/material';
 import { DataProviderContext } from './NCAController';
 import { NcDatatypeType } from '../global/Types';
+import { isElementIdDatatype } from '../middleware/HelperFunctions';
 
 const NUMERIC_TYPE_NAMES = new Set([
     'NcInt16',
@@ -25,7 +26,7 @@ const NUMERIC_TYPE_NAMES = new Set([
     'NcFloat64',
 ]);
 
-function isValidSubmitValue(valueHolder, newValue, isMethod = false) {
+function isValidSubmitValue(valueHolder, newValue, enforceMinimumOne = false) {
     if (valueHolder.name === 'userLabel') {
         return newValue !== '' && (newValue?.length ?? 0) <= 30;
     }
@@ -37,7 +38,7 @@ function isValidSubmitValue(valueHolder, newValue, isMethod = false) {
             return false;
         }
 
-        if (isMethod && (valueHolder.name === 'index' || valueHolder.name === 'level')) {
+        if (enforceMinimumOne) {
             return numericValue >= 1;
         }
 
@@ -80,13 +81,14 @@ export default function EditablePropertyControl({
     oid,
     propertyId,
     isMethod = false,
-    structValue,
+    parentValueHolder,
     index,
     parameterName,
     compact = false,
 }) {
     const datatype = valueHolder?.datatype;
     const value = valueHolder?.value;
+    const structValue = parentValueHolder?.valueMap;
     const invariantType = undefined;
     const isNumericType = NUMERIC_TYPE_NAMES.has(datatype?.typeName);
 
@@ -179,9 +181,16 @@ export default function EditablePropertyControl({
         );
     }
 
-    const canSubmit = isValidSubmitValue(valueHolder, newValue, isMethod);
-    const hasMinimumOneConstraint =
-        isMethod && isNumericType && (valueHolder.name === 'index' || valueHolder.name === 'level');
+    // level and index are only 1-based when they belong to an ID, not for any
+    // parameter that happens to be named that way
+    const isElementIdField =
+        isMethod &&
+        isNumericType &&
+        (valueHolder.name === 'index' || valueHolder.name === 'level') &&
+        isElementIdDatatype(parentValueHolder?.datatype);
+
+    const canSubmit = isValidSubmitValue(valueHolder, newValue, isElementIdField);
+    const hasMinimumOneConstraint = isElementIdField;
 
     const inlineControlSx = {
         display: 'inline-flex',

--- a/is12-client/src/global/Types.ts
+++ b/is12-client/src/global/Types.ts
@@ -95,7 +95,7 @@ export type ValueHolder = {
     name: string | undefined
     description: string | undefined
     isReadOnly: boolean
-    typeName: string
+    typeName?: string // fallback for invariant values where datatype is unknown
 }
 
 export type ValueHolderMap = {

--- a/is12-client/src/global/Types.ts
+++ b/is12-client/src/global/Types.ts
@@ -91,7 +91,7 @@ export type ValueHolder = {
     value : NCAValue | undefined // add a ValueHolderMap and ValueHolder[] here to simplify
     values : ValueHolder[] | undefined // use for sequence
     valueMap : ValueHolderMap | undefined // use for struct
-    datatype: NcDatatype
+    datatype: NcDatatype | undefined
     name: string | undefined
     description: string | undefined
     isReadOnly: boolean

--- a/is12-client/src/global/Types.ts
+++ b/is12-client/src/global/Types.ts
@@ -99,7 +99,7 @@ export type ValueHolder = {
 }
 
 export type ValueHolderMap = {
-    [id: string]: ValueHolder | ValueHolder[]
+    [id: string]: ValueHolder
 }
 export type NodeProps = {
     [id: string]: Prop

--- a/is12-client/src/global/Types.ts
+++ b/is12-client/src/global/Types.ts
@@ -80,6 +80,7 @@ export enum NcDatatypeType {
 export type NcDatatype = {
     type: NcDatatypeType
     typeName: string
+    baseTypeName?: string // for struct inheritance, e.g. NcPropertyId -> NcElementId
     enum: NcEnum[] | null // for enum types
     fields: NcFieldDescriptor[] | null //for struct types
     sequenceType: boolean

--- a/is12-client/src/middleware/DataProvider.ts
+++ b/is12-client/src/middleware/DataProvider.ts
@@ -80,14 +80,30 @@ export default class DataProvider {
     }
 
     private updateProperty = (valueHolder: any, newValue: any, itemIndex: any): ValueHolder => {
+        // The device can notify about an oid that the cached client-side structure has no matching
+        // entry for (e.g. when the Device Model is restructured live and objects are added/removed/reparented).
+        // In those cases valueHolder is undefined; skip the update rather than crashing on a dereference.
+        if (!valueHolder) {
+            if (this.debug) console.warn(`Ignoring property update: no cached valueHolder to update (itemIndex=${JSON.stringify(itemIndex)})`)
+            return valueHolder
+        }
+
         if (itemIndex !== null) {
             var index = itemIndex as number
+            if (!valueHolder.values || valueHolder.values[index] === undefined) {
+                if (this.debug) console.warn(`Unknown sequence item index ${index} is not present in the cached values`)
+                return valueHolder
+            }
             valueHolder.values[index] = this.updateProperty(valueHolder.values[index], newValue, null)
         }
         else {
             if (valueHolder.valueMap) { // is it a struct
                 let nv = newValue as any
                 for (const elem of Object.keys(nv)) {
+                    if (valueHolder.valueMap[elem] === undefined) {
+                        if (this.debug) console.warn(`Unknown struct field "${elem}" is not present in the cached valueMap`)
+                        continue
+                    }
                     valueHolder.valueMap[elem] = this.updateProperty(valueHolder.valueMap[elem], nv[elem], null)
                 }
             } else {
@@ -108,10 +124,28 @@ export default class DataProvider {
 
             var newValue = prop.eventData.value
 
-            var valueHolder = this.propertyMap[prop.oid].ValueHolderMap![propId] as any
+            const objectEntry = this.propertyMap[prop.oid]
+
+            if (!objectEntry) {
+                if (this.debug) console.warn(`Unknown oid ${prop.oid}`)
+                return
+            }
+
+            if (!objectEntry.ValueHolderMap || objectEntry.ValueHolderMap[propId] === undefined) {
+                if (this.debug) console.warn(`Unknown propertyId ${propId} on oid ${prop.oid}`)
+                return
+            }
+
+            var valueHolder = objectEntry.ValueHolderMap[propId] as any
             valueHolder = this.updateProperty(valueHolder, newValue, prop.eventData.sequenceItemIndex)
-            this.propertyMap[prop.oid].ValueHolderMap![propId] = valueHolder
-            this.propertyMap[prop.oid].State![propId](valueHolder.value)
+            objectEntry.ValueHolderMap[propId] = valueHolder
+
+            if (objectEntry.State && objectEntry.State[propId]) {
+                objectEntry.State[propId](valueHolder.value)
+            }
+            else if (this.debug) {
+                console.warn(`Updated cached value for oid=${prop.oid} propertyId=${propId} but no React state setter is registered, so the UI will not reflect this change`)
+            }
         })
     }
 

--- a/is12-client/src/middleware/DataProvider.ts
+++ b/is12-client/src/middleware/DataProvider.ts
@@ -303,7 +303,7 @@ export default class DataProvider {
             // This is an object
             var objectVal = {} as GenericMap
             for (const elem of Object.keys(parentValue)) {
-                var vh = parentValue[elem] as ValueHolder
+                var vh = parentValue[elem]
                 let name = vh.name as string
                 objectVal[name] = vh.value
             }
@@ -349,7 +349,7 @@ export default class DataProvider {
             // This is an object
             var objectVal = {} as GenericMap
             for (const elem of Object.keys(parentValue)) {
-                var vh = parentValue[elem] as ValueHolder
+                var vh = parentValue[elem]
                 let name = vh.name as string
                 objectVal[name] = vh.value
             }
@@ -398,7 +398,7 @@ export default class DataProvider {
             this.propertyMap[oid].Methods![methodIdString].ValueHolderMap![parameterName] = valueHolder
         }
         else {
-            var tmpValueHolder = this.propertyMap[oid].Methods![methodIdString].ValueHolderMap![parameterName] as ValueHolder
+            var tmpValueHolder = this.propertyMap[oid].Methods![methodIdString].ValueHolderMap![parameterName]
             var tmpValueHolderMap = tmpValueHolder.valueMap as ValueHolderMap
             var name = valueHolder.name as string
             tmpValueHolderMap[name] = valueHolder
@@ -421,7 +421,7 @@ export default class DataProvider {
             var param = {} as GenericMap
 
             for (const elem of Object.keys(valueHolder.valueMap)) {
-                var vh = valueHolder.valueMap[elem] as ValueHolder
+                var vh = valueHolder.valueMap[elem]
                 param[elem] = this.makeParameter(vh)
             }
 

--- a/is12-client/src/middleware/DataProvider.ts
+++ b/is12-client/src/middleware/DataProvider.ts
@@ -31,7 +31,7 @@ import {NCANotificationResponseMessage, NcMethodStatus} from "../global/Types";
 import {getClassDescriptor, getBlockProps, getFormattedBlockNodes, subscribeToObjects, getDatatypes, getRootBlock } from "../backend/BlockNodeCommands";
 import {NCAConnection} from "../backend/ConnectionHandler";
 import {getPropertyValue, setPropertyValue, setSequenceItem, invokeMethod} from "../global/IS12CommandTemplates";
-import {makeValueHolder} from "./HelperFunctions"
+import {getValueHolderTypeName, makeValueHolder} from "./HelperFunctions"
 
 export default class DataProvider {
 
@@ -297,7 +297,7 @@ export default class DataProvider {
     // send the entire updated struct to the Node)
     public changeValue = (prop_parent_oid: number, propId: NcElementId, newVal: NCAValue, parentValue: ValueHolderMap | undefined, valueHolder: ValueHolder) => {
 
-        const castVal = this.castValue(valueHolder.datatype.typeName, newVal)
+        const castVal = this.castValue(getValueHolderTypeName(valueHolder), newVal)
 
         if (parentValue) {
             // This is an object
@@ -343,7 +343,7 @@ export default class DataProvider {
     // send the entire updated struct to the Node)
     public changeSequencePropertyValue = (prop_parent_oid: number, propId: NcElementId, index: number, newVal: NCAValue, parentValue: ValueHolderMap | undefined, valueHolder: ValueHolder) => {
 
-        const castVal = this.castValue(valueHolder.datatype.typeName, newVal)
+        const castVal = this.castValue(getValueHolderTypeName(valueHolder), newVal)
 
         if (parentValue) {
             // This is an object
@@ -386,7 +386,7 @@ export default class DataProvider {
     // Change method parameter value
     public changeParameter = (oid: number, methodId: NcElementId, parameterName: string, newVal: NCAValue, parentValue: ValueHolderMap | undefined, valueHolder: ValueHolder, invariantHint: string | undefined) => {
 
-        // If this an invariant type then use the invariantHint to set a typeName on the ValueHolder
+        // If this an invariant type then use the invariantHint as the fallback type name
         if (valueHolder.datatype === undefined && invariantHint !== undefined) {
             valueHolder.typeName = invariantHint
         }
@@ -428,8 +428,7 @@ export default class DataProvider {
             return param
         }
 
-        var typeName = valueHolder.datatype ? valueHolder.datatype.typeName : (valueHolder.typeName ? valueHolder.typeName : "NcString")
-        return this.castValue(typeName, valueHolder.value)
+        return this.castValue(getValueHolderTypeName(valueHolder), valueHolder.value)
     }
 
     public invokeMethod = async (

--- a/is12-client/src/middleware/HelperFunctions.ts
+++ b/is12-client/src/middleware/HelperFunctions.ts
@@ -80,6 +80,10 @@ export function isElementIdDatatype(datatype: NcDatatype | undefined) {
     return datatype.baseTypeName === 'NcElementId';
 }
 
+export function getValueHolderTypeName(valueHolder: ValueHolder) {
+    return valueHolder.datatype?.typeName ?? valueHolder.typeName ?? "NcString";
+}
+
 export function makeDefaultValue(datatype: string | undefined) {
     if (datatype === "NcInt16" || datatype === "NcInt32" || datatype === "NcInt64" || datatype === "NcUint16" || datatype === "NcUint32" || datatype === "NcUint64") {
         return 0;
@@ -150,8 +154,7 @@ export const makeValueHolder = async (value: any, isSequence: boolean, datatype:
                     datatype: datatype,
                     name: name,
                     description: description,
-                    isReadOnly: isReadOnly,
-                    typeName: typeName
+                    isReadOnly: isReadOnly
             }
         }
 
@@ -186,8 +189,7 @@ export const makeValueHolder = async (value: any, isSequence: boolean, datatype:
                     datatype: datatype,
                     name: name,
                     description: description,
-                    isReadOnly: isReadOnly,
-                    typeName: typeName
+                    isReadOnly: isReadOnly
                 }
             }
         }
@@ -200,7 +202,6 @@ export const makeValueHolder = async (value: any, isSequence: boolean, datatype:
         datatype: datatype,
         name: name,
         description: description,
-        isReadOnly: isReadOnly,
-        typeName: typeName
+        isReadOnly: isReadOnly
     }
 }

--- a/is12-client/src/middleware/HelperFunctions.ts
+++ b/is12-client/src/middleware/HelperFunctions.ts
@@ -77,7 +77,7 @@ export function isElementIdDatatype(datatype: NcDatatype | undefined) {
     if (!datatype || datatype.type !== NcDatatypeType.NcStruct) {
         return false;
     }
-    return datatype.typeName === 'NcElementId' || datatype.baseTypeName === 'NcElementId';
+    return datatype.baseTypeName === 'NcElementId';
 }
 
 export function makeDefaultValue(datatype: string | undefined) {
@@ -95,7 +95,7 @@ export function makeDefaultValue(datatype: string | undefined) {
 }
 
 
-export const makeValueHolder = async (value: any, isSequence: boolean, datatype: NcDatatype, isReadOnly: boolean, typeName: string, name: string | undefined, description: string | undefined, defaultValues?: boolean ): Promise<ValueHolder> => {
+export const makeValueHolder = async (value: any, isSequence: boolean, datatype: NcDatatype | undefined, isReadOnly: boolean, typeName: string, name: string | undefined, description: string | undefined, defaultValues?: boolean ): Promise<ValueHolder> => {
 
     if (datatype === undefined) {
         return {

--- a/is12-client/src/middleware/HelperFunctions.ts
+++ b/is12-client/src/middleware/HelperFunctions.ts
@@ -72,6 +72,14 @@ export function isStructDatatype(valueHolder: ValueHolder) {
     return false;
 }
 
+// An "ID" datatype is NcElementId or a datatype derived from it.
+export function isElementIdDatatype(datatype: NcDatatype | undefined) {
+    if (!datatype || datatype.type !== NcDatatypeType.NcStruct) {
+        return false;
+    }
+    return datatype.typeName === 'NcElementId' || datatype.baseTypeName === 'NcElementId';
+}
+
 export function makeDefaultValue(datatype: string | undefined) {
     if (datatype === "NcInt16" || datatype === "NcInt32" || datatype === "NcInt64" || datatype === "NcUint16" || datatype === "NcUint32" || datatype === "NcUint64") {
         return 0;
@@ -154,8 +162,18 @@ export const makeValueHolder = async (value: any, isSequence: boolean, datatype:
 
                 var structValues = {} as ValueHolderMap
 
+                // level and index of an ID are 1-based, so their defaults are 1 rather than 0
+                const isIdStruct = isElementIdDatatype(datatype)
+
                 for (const field of fields) {
-                    let actualValue = defaultValues ? makeDefaultValue(field.datatype?.typeName) : typeof value === 'object' ? value[field.name] : undefined
+                    let actualValue
+                    if (defaultValues) {
+                        actualValue = isIdStruct && (field.name === 'level' || field.name === 'index')
+                            ? 1
+                            : makeDefaultValue(field.datatype?.typeName)
+                    } else {
+                        actualValue = typeof value === 'object' ? value[field.name] : undefined
+                    }
                     var stv = makeValueHolder(actualValue, field.isSequence, field.datatype as NcDatatype, isReadOnly, field.typeName, field.name, field.description) as Promise<ValueHolder>
                     structValues[field.name] = await stv
                 }


### PR DESCRIPTION
- Currently any method parameter called index or level will have a minimum applied of 1
- This is incorrect for some parameters, for instance the index parameter of the GetSequenceItem method
- The minimum is only required for fields of an ID derived from NcElementId
- Slight refactoring to store baseDataType for structs so know whether a field/parameter is part of an NcElementId or not
- Used as opportunity to tidy up and simplify the ValueHolderMap 