### PR TITLE
Update GitHub Actions to versions which run on Node.js 24

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,9 +13,9 @@ jobs:
   build_and_test:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
 
     - name: set environment variables
       shell: bash
@@ -34,7 +34,7 @@ jobs:
         yarn test --passWithNoTests --coverage --watchAll=false
 
     - name: install python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: 3.8
 
@@ -106,12 +106,12 @@ jobs:
         export SHEET=https://docs.google.com/spreadsheets/d/${{ env.SECRET_RESULTS_SHEET_ID }}
         python nmos-testing/utilities/run-test-suites/gsheetsImport/resultsImporter.py --credentials ${{ env.GDRIVE_CREDENTIALS }} --sheet "$SHEET" --insert --json nmos-testing/results/${{ env.GITHUB_COMMIT }}-*.json || echo "upload failed"
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: badges
         path: ${{ runner.workspace }}/nmos-js/nmos-testing/badges
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: results
         path: ${{ runner.workspace }}/nmos-js/nmos-testing/results
@@ -121,7 +121,7 @@ jobs:
     needs: [build_and_test]
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
 
     - name: set environment variables
       shell: bash
@@ -131,7 +131,7 @@ jobs:
         echo "GITHUB_WORKSPACE=${{ github.workspace }}" >> $GITHUB_ENV
         echo "RUNNER_WORKSPACE=${{ runner.workspace }}" >> $GITHUB_ENV
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         path: ${{ runner.workspace }}/artifacts
 


### PR DESCRIPTION
Recent runs of build-test emit warnings because the pinned actions target the deprecated Node.js 20 runtime and are being forced to run on Node.js 24, see https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/.

Update the pinned actions to their current major versions, which all target Node.js 24:

- actions/checkout v2/v3 to v7
- actions/setup-node v4 to v7
- actions/setup-python v4 to v7
- actions/upload-artifact v4 to v7
- actions/download-artifact v4 to v8

These are drop-in upgrades for this workflow. The artifact actions have shared the same backend since v4, so make_badges still downloads the artifacts uploaded by build_and_test, and setup-python still provides Python 3.8 on ubuntu-22.04.
