### PR TITLE
Fix Connection API Bridge routing, HEAD, and Location redirects

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -10,6 +10,23 @@ env:
   SECRET_GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
   SECRET_RESULTS_SHEET_ID: ${{ secrets.RESULTS_SHEET_ID }}
 jobs:
+  connection_bridge_lua:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: ConnectionBridge/envoy
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: install lua
+      working-directory: ${{ github.workspace }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y lua5.1
+
+    - name: unit test location rewrite
+      run: lua5.1 location_rewrite_test.lua
+
   build_and_test:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -25,7 +25,7 @@ jobs:
         sudo apt-get install -y lua5.1
 
     - name: unit test location rewrite
-      run: lua5.1 location_rewrite_test.lua
+      run: lua5.1 location_rewrite_test.lua -v
 
   build_and_test:
     runs-on: ubuntu-22.04

--- a/ConnectionBridge/README.md
+++ b/ConnectionBridge/README.md
@@ -164,4 +164,16 @@ The nmos-js client offers a **Connection Bridge** setting with three modes:
 
 ## Status
 
-Phase 1 (HTTP browser and upstream access, file-based dynamic configuration, `GET`/`POST`/`PATCH`, no response rewriting) is implemented, plus health checking and multi-endpoint failover from Phase 2. Not yet implemented: response size limits, HTTPS upstreams, authentication translation, mTLS, and an xDS control plane.
+Phase 1 is implemented, plus health checking and multi-endpoint failover from Phase 2:
+
+- HTTP browser and upstream access, file-based dynamic configuration
+- `GET`/`HEAD`/`POST`/`PATCH`
+- Upstream 3xx `Location` handling (see below)
+
+Not yet implemented: response size limits, HTTPS upstreams, authentication translation, mTLS, and an xDS control plane.
+
+`Location` handling uses each target's Connection API `base_path` (the path of the Device control `href`, typically `/x-nmos/connection/v1.1` or similar):
+
+- Absolute or scheme-relative (filled with the client scheme) Locations whose scheme and authority match a Device Connection API candidate and whose path stays under that `base_path` are rewritten onto the bridge; other absolute Locations are forwarded unchanged (including candidate URLs outside `base_path`, e.g. `http://device/x-manifest/...`).
+- Path-relative and root-relative Locations are resolved against the upstream Connection API path and rewritten onto the bridge when they stay under `base_path`; relatives outside `base_path` are rejected with `502` and an NMOS error body (`x-nmos-bridge-error` describes the unsupported Location), since an absolute Device URL cannot be reconstructed without knowing which candidate Envoy selected.
+- Envoy internal redirects are not used: absolute Device Locations under `/x-nmos/` would be re-routed by path onto the Registry `/x-nmos/` routes.

--- a/ConnectionBridge/README.md
+++ b/ConnectionBridge/README.md
@@ -83,6 +83,7 @@ Location rewrite policy is covered by Lua unit tests (Lua 5.1 / LuaJIT, matching
 
 ```bash
 lua5.1 location_rewrite_test.lua
+lua5.1 location_rewrite_test.lua -v   # per-case status lines
 ```
 
 ## Running

--- a/ConnectionBridge/README.md
+++ b/ConnectionBridge/README.md
@@ -77,6 +77,14 @@ Envoy health checks the candidates and fails over from higher to lower priority 
 
 Controls that are not safe to proxy are logged and ignored: missing or malformed hrefs, unsupported schemes (Phase 1 supports `http` upstreams only), hrefs whose path is inconsistent with the advertised version, and duplicates after normalization.
 
+## Testing
+
+Location rewrite policy is covered by Lua unit tests (Lua 5.1 / LuaJIT, matching Envoy). From `envoy/`:
+
+```bash
+lua5.1 location_rewrite_test.lua
+```
+
 ## Running
 
 ```bash

--- a/ConnectionBridge/README.md
+++ b/ConnectionBridge/README.md
@@ -37,20 +37,33 @@ Methods are restricted to `GET`, `POST`, `PATCH` and `OPTIONS`. Query strings, m
 ```text
 Browser
     |
-    v
- Envoy
+    +--(HTTP / WebSocket)------> Registry Query API
     |
-    +--> Registry APIs
+    +--(HTTP)------------------> Envoy
+                                    |
+                                    +--> /x-nmos-bridge/... --> Device Connection APIs
+                                    |
+                                    +--> /x-nmos -> ["query/"] (fixed listing)
+                                    |
+                                    +--> /x-nmos/query/... (convenience)
+                                    |         --> Registry Query API
+                                    |
+                                    +--> /x-dns-sd/... (convenience)
+                                    |         --> Registry DNS-SD API
+                                    |
+                                    +--> /log/... (convenience)
+                                    |         --> Registry Logging API
+                                    |
+                                    +--> /... (optional) --> nmos-js app
+
+Adapter (server-side; not on the browser path)
     |
-    +--> NMOS Connection API Bridge
-             |
-             v
-        Device Connection APIs
+    +--(HTTP / WebSocket)------> Registry Query API (Device discovery)
 ```
 
 The Connection API Bridge consists of Envoy and the adapter service:
 
-- **Envoy** performs all proxying: routing, request size limits, timeouts, retry policy, health checking and failover, and access logging of `POST` and `PATCH` requests.
+- **Envoy** proxies browser HTTP to Device Connection APIs on `/x-nmos-bridge/...` (required for the bridge). It may also proxy the Query API on `/x-nmos/query/...`, DNS-SD on `/x-dns-sd/...`, and the nmos-js app on `/` as optional convenience. `GET /x-nmos/` returns a fixed listing of `["query/"]` so discovery matches what is actually proxied. Other `/x-nmos/` APIs (Registration, Node, …) are not proxied — they may use different ports. It applies routing, request size limits, timeouts, retry policy, health checking and failover, and access logging of `POST` and `PATCH` requests. It does not proxy Query API WebSocket subscriptions.
 - **The adapter** (`adapter/`) converts Registry state into Envoy configuration. It tracks Devices through a [Query API WebSocket subscription](https://specs.amwa.tv/is-04/branches/v1.3.x/docs/4.2._Behaviour_-_Querying.html) (non-persistent, `resource_path` `/devices`), extracts Connection API controls, and generates Envoy routes and clusters, atomically replacing the dynamic configuration files (`rds.json`, `cds.json`) which Envoy reloads via filesystem watch. The adapter does not proxy traffic and does not determine runtime health.
 
   On connecting, the Registry sends a sync of all current Devices, then pushes added, modified and removed events; the adapter rebuilds configuration on each change. If the connection is interrupted, the adapter resubscribes with exponential backoff and the fresh sync re-establishes all mappings, including Devices that were removed while disconnected. The last good configuration keeps being served until the new sync arrives.
@@ -96,8 +109,10 @@ Edit `docker-compose.yml` first to point the adapter at the deployment:
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `REGISTRY_QUERY_URL` | Query API URL used for Device discovery; its host and port are also used as the upstream for Envoy's `/x-nmos/` routes | (required) |
-| `APP_URL` | nmos-js application URL used as the upstream for Envoy's catch-all `/` route; if unset, no application route is configured | (none) |
+| `REGISTRY_QUERY_URL` | Query API URL used by the adapter for Device discovery; its host and port are the upstream for Envoy's `/x-nmos/query/` routes (and `/x-dns-sd/` / `/log/` when the corresponding override is unset). The path in this URL is not used for proxying. | (required) |
+| `REGISTRY_DNS_SD_URL` | optional upstream for Envoy's `/x-dns-sd/` routes when DNS-SD is not on the same host/port as `REGISTRY_QUERY_URL` | (same as Query) |
+| `REGISTRY_LOGGING_URL` | optional upstream for Envoy's `/log/` routes when Logging is not on the same host/port as `REGISTRY_QUERY_URL` | (same as Query) |
+| `APP_URL` | upstream for Envoy's catch-all `/` route (standalone nmos-js at `/`, or a Registry that serves the UI under `/admin`); if unset, no application route is configured | (none) |
 | `ROUTE_TIMEOUT_SECONDS` | upstream request timeout | `15` |
 | `MAX_UPDATE_RATE_MS` | subscription `max_update_rate_ms` (event coalescing) | `100` |
 | `RECONNECT_MIN_MS` | initial WebSocket reconnect backoff | `1000` |
@@ -107,29 +122,54 @@ Edit `docker-compose.yml` first to point the adapter at the deployment:
 
 Envoy listens on port 8080 and routes:
 
-- `/x-nmos-bridge/v1.0/devices/...` to Device Connection APIs
-- `/x-nmos/...` to the Registry
-- everything else to the nmos-js app, if `APP_URL` is set
+- `/x-nmos` and `/x-nmos/` return a fixed IS-04-style listing of `["query/"]` (only what this front door proxies)
+- `/x-nmos/query/...` to the Registry Query API (convenience; see Deployment)
+- `/x-dns-sd/...` to the Registry DNS-SD / MDNS API (convenience; same upstream as Query unless `REGISTRY_DNS_SD_URL` is set)
+- `/log/...` to the Registry Logging API (convenience; same upstream as Query unless `REGISTRY_LOGGING_URL` is set)
+- everything else to the nmos-js app (or Registry UI), if `APP_URL` is set
 
 ## Deployment
 
-Deploy Envoy as the browser-facing endpoint for both the Query API and the
-Connection API Bridge. Configure nmos-js to use the Query API through Envoy,
-for example:
+The bridge itself only requires browser HTTP access to
+`/x-nmos-bridge/v1.0/...` on Envoy. Proxying Query HTTP on `/x-nmos/query/...`,
+DNS-SD on `/x-dns-sd/...`, and Logging on `/log/...` is convenience (one
+browser-facing HTTP origin when the SPA is also served via `APP_URL`, or when
+those SPA settings point at Envoy). Registration, Node, and other non-Query
+`/x-nmos/` APIs are not proxied; `GET /x-nmos/` therefore lists only `query/`,
+rather than reflecting the Registry's full `/x-nmos/` catalogue. By default
+`/x-dns-sd/` and `/log/` use the same upstream host and port as
+`REGISTRY_QUERY_URL`; set `REGISTRY_DNS_SD_URL` or `REGISTRY_LOGGING_URL` when
+those APIs listen elsewhere (for example a different `mdns_port` or
+`logging_port`).
 
-```text
-http://controller.example.com:8080/x-nmos/query/v1.3
-```
+`APP_URL` may be a standalone nmos-js host (SPA at `/`) or a Registry that
+serves the UI under `/admin` (nmos-cpp-registry). In both cases Envoy's `/log/`
+route supports the SPA Logging API default (`{origin}/log/v1.0`).
 
-The client derives the bridge origin from the configured Query API, so the
-corresponding bridge URL is:
+Configure nmos-js **Connection Bridge API** to the bridge base, for example:
 
 ```text
 http://controller.example.com:8080/x-nmos-bridge/v1.0
 ```
 
-The adapter must be able to reach the Query API and the WebSocket URL
-advertised when it creates the Query API subscription. Set
+The default (when unset in config or Settings) is this page's origin plus
+`/x-nmos-bridge/v1.0`.
+
+A layout that also proxies Query and Logging through Envoy might use:
+
+```text
+Query API:              http://controller.example.com:8080/x-nmos/query/v1.3
+Logging API:            http://controller.example.com:8080/log/v1.0
+Connection Bridge API:  http://controller.example.com:8080/x-nmos-bridge/v1.0
+```
+
+Query API WebSocket subscriptions are not proxied by Envoy. Subscription
+`ws_href` values are absolute URIs (`format: uri`) advertised by the
+Registry and often use a different port than Query HTTP (for example
+nmos-cpp-registry's `query_ws_port`). Browser clients that open those
+sockets connect to the Registry (or whatever `ws_href` names), not through
+Envoy. The adapter's server-side subscription is separate: it must reach
+the Query API and the WebSocket URL from the subscription response. Set
 `REGISTRY_QUERY_WS_URL` when the advertised `ws_href` uses a scheme, host
 name or port which is not reachable from the adapter, for example
 `ws://192.168.6.101:81`.
@@ -147,9 +187,10 @@ file-based arrangement. A deployment with independently scaled Envoy
 instances would require an xDS control plane, which is not currently
 implemented.
 
-If nmos-js is served separately, expose Envoy as the Query API endpoint and
-configure nmos-js to use it. Alternatively, set `APP_URL` and use Envoy as a
-single origin for nmos-js, the Registry APIs, and the bridge.
+If nmos-js is served separately, set Query API, Logging API and Connection
+Bridge API as needed (Registry and/or Envoy). Alternatively, set `APP_URL`
+and use Envoy as a single origin for nmos-js, Query/DNS-SD/Logging APIs, and
+the bridge.
 
 ### Container Orchestration
 
@@ -163,13 +204,14 @@ and are not included here.
 
 ## Browser Application Behavior
 
-The nmos-js client offers a **Connection Bridge** setting with three modes:
+The nmos-js client offers a **Connection Bridge Mode** and a separate
+**Connection Bridge API**:
 
 - **No Bridge** (default): use the Device control hrefs directly, never the bridge.
 - **Auto Bridge**: the preferred access sequence. Use the Device control href directly; if inaccessible, use the bridge URL; cache the successful access path per Device. Note that on first access to a Device that is not directly reachable, the browser must wait for the direct attempt to fail (up to 5 seconds) before falling back; the cached path avoids this on subsequent accesses.
 - **Forced Bridge**: always use the bridge, skipping direct attempts entirely. Useful when it is known that no Device is reachable from the browser.
 
-`POST` and `PATCH` requests are not automatically retried via alternate paths; they follow whichever path was resolved for the Device. The client expects the bridge on the same host as the configured Query API.
+`POST` and `PATCH` requests are not automatically retried via alternate paths; they follow whichever path was resolved for the Device. Bridge requests use the configured Connection Bridge API (default: SPA origin + `/x-nmos-bridge/v1.0`).
 
 ## Status
 
@@ -185,4 +227,4 @@ Not yet implemented: response size limits, HTTPS upstreams, authentication trans
 
 - Absolute or scheme-relative (filled with the client scheme) Locations whose scheme and authority match a Device Connection API candidate and whose path stays under that `base_path` are rewritten onto the bridge; other absolute Locations are forwarded unchanged (including candidate URLs outside `base_path`, e.g. `http://device/x-manifest/...`).
 - Path-relative and root-relative Locations are resolved against the upstream Connection API path and rewritten onto the bridge when they stay under `base_path`; relatives outside `base_path` are rejected with `502` and an NMOS error body (`x-nmos-bridge-error` describes the unsupported Location), since an absolute Device URL cannot be reconstructed without knowing which candidate Envoy selected.
-- Envoy internal redirects are not used: absolute Device Locations under `/x-nmos/` would be re-routed by path onto the Registry `/x-nmos/` routes.
+- Envoy internal redirects are not used: absolute Device Locations under `/x-nmos/` would be matched by path (e.g. `/x-nmos/query/` onto the Query cluster) rather than treated as Device Connection API targets.

--- a/ConnectionBridge/adapter/index.js
+++ b/ConnectionBridge/adapter/index.js
@@ -17,6 +17,22 @@ const REGISTRY_QUERY_URL = (process.env.REGISTRY_QUERY_URL || '').replace(
     ''
 );
 const APP_URL = process.env.APP_URL || '';
+// optional override for /x-dns-sd/ upstream; when unset, use the same host
+// and port as REGISTRY_QUERY_URL (typical when nmos-cpp mdns_port matches
+// query_port). Only hostname and port are used for the Envoy cluster; any
+// path in either URL is ignored (Envoy forwards the client request path).
+const REGISTRY_DNS_SD_URL = (process.env.REGISTRY_DNS_SD_URL || '').replace(
+    /\/$/,
+    ''
+);
+// optional override for /log/ upstream; when unset, use the same host and
+// port as REGISTRY_QUERY_URL (typical when nmos-cpp logging_port matches
+// query_port). Only hostname and port are used for the Envoy cluster; any
+// path in either URL is ignored (Envoy forwards the client request path).
+const REGISTRY_LOGGING_URL = (process.env.REGISTRY_LOGGING_URL || '').replace(
+    /\/$/,
+    ''
+);
 const OUTPUT_DIR = process.env.OUTPUT_DIR || '/etc/envoy/dynamic';
 const ROUTE_TIMEOUT_SECONDS = Number(process.env.ROUTE_TIMEOUT_SECONDS) || 15;
 // subscription update coalescing and WebSocket reconnect backoff
@@ -183,6 +199,8 @@ const clusterName = target =>
     )}`;
 
 const staticClusterFromUrl = (name, urlString) => {
+    // Only scheme defaults, hostname, and port are used; any path in
+    // urlString is ignored (Envoy forwards the client request path).
     const url = new URL(urlString);
     return {
         '@type': 'type.googleapis.com/envoy.config.cluster.v3.Cluster',
@@ -258,18 +276,18 @@ const bridgeCluster = target => {
     };
 };
 
-const nmosError = (status, error) =>
-    JSON.stringify({ code: status, error, debug: null });
-
-const directResponse = (status, error) => ({
+const directResponse = (status, jsonBody) => ({
     direct_response: {
         status,
-        body: { inline_string: nmosError(status, error) },
+        body: { inline_string: JSON.stringify(jsonBody) },
     },
     response_headers_to_add: [
         { header: { key: 'content-type', value: 'application/json' } },
     ],
 });
+
+const directErrorResponse = (status, error) =>
+    directResponse(status, { code: status, error, debug: null });
 
 const bridgeRoutes = target => {
     // path_separated_prefix matches the version path exactly or with a
@@ -353,7 +371,7 @@ const bridgeRoutes = target => {
         // any other method on a known target
         {
             match: { path_separated_prefix: pathPrefix },
-            ...directResponse(405, 'Method not allowed'),
+            ...directErrorResponse(405, 'Method not allowed'),
         },
     ];
 };
@@ -385,18 +403,59 @@ const routeConfiguration = targets => ({
                 // controls produce routes, everything else stops here
                 {
                     match: { prefix: `${BRIDGE_PREFIX}/` },
-                    ...directResponse(404, 'Unknown bridge target'),
+                    ...directErrorResponse(404, 'Unknown bridge target'),
                 },
-                // Registry APIs
+                // Query API (host/port from REGISTRY_QUERY_URL; path is not
+                // rewritten — clients request /x-nmos/query...)
                 {
-                    match: { prefix: '/x-nmos/' },
+                    match: { path_separated_prefix: '/x-nmos/query' },
                     route: {
-                        cluster: 'registry',
+                        cluster: 'registry_query',
+                        timeout: `${ROUTE_TIMEOUT_SECONDS}s`,
+                    },
+                },
+                // IS-04 /x-nmos base: list only APIs this Envoy front door
+                // actually proxies (not Registration/Node/etc.)
+                {
+                    match: { path: '/x-nmos' },
+                    ...directResponse(200, ['query/']),
+                },
+                {
+                    match: { path: '/x-nmos/' },
+                    ...directResponse(200, ['query/']),
+                },
+                // DNS-SD / MDNS API (same host/port as Query unless
+                // REGISTRY_DNS_SD_URL is set)
+                {
+                    match: { path_separated_prefix: '/x-dns-sd' },
+                    route: {
+                        cluster: REGISTRY_DNS_SD_URL
+                            ? 'registry_dns_sd'
+                            : 'registry_query',
+                        timeout: `${ROUTE_TIMEOUT_SECONDS}s`,
+                    },
+                },
+                // Logging API (same host/port as Query unless
+                // REGISTRY_LOGGING_URL is set)
+                {
+                    match: { path_separated_prefix: '/log' },
+                    route: {
+                        cluster: REGISTRY_LOGGING_URL
+                            ? 'registry_logging'
+                            : 'registry_query',
                         timeout: `${ROUTE_TIMEOUT_SECONDS}s`,
                     },
                 },
                 ...(APP_URL
-                    ? [{ match: { prefix: '/' }, route: { cluster: 'app' } }]
+                    ? [
+                          {
+                              match: { prefix: '/' },
+                              route: {
+                                  cluster: 'app',
+                                  timeout: `${ROUTE_TIMEOUT_SECONDS}s`,
+                              },
+                          },
+                      ]
                     : []),
             ],
         },
@@ -424,7 +483,13 @@ const writeResource = (filename, resources, state) => {
 
 const apply = (targets, state) => {
     const clusters = [
-        staticClusterFromUrl('registry', REGISTRY_QUERY_URL),
+        staticClusterFromUrl('registry_query', REGISTRY_QUERY_URL),
+        ...(REGISTRY_DNS_SD_URL
+            ? [staticClusterFromUrl('registry_dns_sd', REGISTRY_DNS_SD_URL)]
+            : []),
+        ...(REGISTRY_LOGGING_URL
+            ? [staticClusterFromUrl('registry_logging', REGISTRY_LOGGING_URL)]
+            : []),
         ...(APP_URL ? [staticClusterFromUrl('app', APP_URL)] : []),
         ...targets.map(bridgeCluster),
     ];

--- a/ConnectionBridge/adapter/index.js
+++ b/ConnectionBridge/adapter/index.js
@@ -127,13 +127,16 @@ const collectTargets = devices => {
             }
             const candidates = targets.get(key).candidates;
             const host = href.hostname;
-            const port = Number(href.port) || 80;
+            // URL.port is empty when the href omits an explicit port
+            const scheme = href.protocol.replace(/:$/, '');
+            const port = Number(href.port) || (scheme === 'https' ? 443 : 80);
             // de-duplicate normalized hrefs
             if (
                 candidates.some(
                     c =>
                         c.host === host &&
                         c.port === port &&
+                        c.scheme === scheme &&
                         c.basePath === basePath
                 )
             ) {
@@ -142,27 +145,29 @@ const collectTargets = devices => {
             candidates.push({
                 host,
                 port,
+                scheme,
                 basePath,
                 priority: priorityFor(host),
             });
         }
     }
     // all candidates in a cluster share one route rewrite, so if hrefs for
-    // the same target disagree on base path, keep only those that share a
-    // path with the most preferred candidate
+    // the same target disagree on scheme or base path, keep only those that
+    // share both with the most preferred candidate
     for (const target of targets.values()) {
         target.candidates.sort((a, b) => a.priority - b.priority);
-        const basePath = target.candidates[0].basePath;
+        const { scheme, basePath } = target.candidates[0];
         for (const c of target.candidates) {
-            if (c.basePath !== basePath) {
+            if (c.scheme !== scheme || c.basePath !== basePath) {
                 logOnce(
-                    `dropping candidate with differing base path for Device ${target.deviceId} ${target.version}: ${c.host}:${c.port}${c.basePath}`
+                    `dropping candidate with differing scheme or base path for Device ${target.deviceId} ${target.version}: ${c.scheme}://${c.host}:${c.port}${c.basePath}`
                 );
             }
         }
         target.candidates = target.candidates.filter(
-            c => c.basePath === basePath
+            c => c.scheme === scheme && c.basePath === basePath
         );
+        target.scheme = scheme;
         target.basePath = basePath;
     }
     return [...targets.values()].sort((a, b) =>
@@ -273,6 +278,35 @@ const bridgeRoutes = target => {
     // sub-path) when rewriting onto the Device Connection API basePath,
     // so trailing-slash handling stays with the upstream per IS-04/IS-05.
     const pathPrefix = `${BRIDGE_PREFIX}/devices/${target.deviceId}/connection/${target.version}`;
+    // Envoy 1.31 set_metadata has no per-route config; LuaPerRoute on a
+    // dedicated filter writes Location-rewrite context into dynamic metadata
+    // for location_rewrite.lua. Values are NMOS paths / host:port lists.
+    const escapeLua = s =>
+        String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const formatAuthority = c =>
+        c.host.includes(':') ? `[${c.host}]:${c.port}` : `${c.host}:${c.port}`;
+    const upstreamAuthorities = target.candidates
+        .map(formatAuthority)
+        .join(',');
+    const locationMeta = {
+        typed_per_filter_config: {
+            'nmos.bridge.location_meta': {
+                '@type':
+                    'type.googleapis.com/envoy.extensions.filters.http.lua.v3.LuaPerRoute',
+                source_code: {
+                    inline_string: [
+                        'function envoy_on_request(request_handle)',
+                        '  local md = request_handle:streamInfo():dynamicMetadata()',
+                        `  md:set("nmos_bridge_location", "base_path", "${escapeLua(target.basePath)}")`,
+                        `  md:set("nmos_bridge_location", "bridge_path", "${escapeLua(pathPrefix)}")`,
+                        `  md:set("nmos_bridge_location", "upstream_scheme", "${escapeLua(target.scheme)}")`,
+                        `  md:set("nmos_bridge_location", "upstream_authorities", "${escapeLua(upstreamAuthorities)}")`,
+                        'end',
+                    ].join('\n'),
+                },
+            },
+        },
+    };
     const action = {
         cluster: clusterName(target),
         prefix_rewrite: target.basePath,
@@ -299,6 +333,7 @@ const bridgeRoutes = target => {
                     num_retries: 2,
                 },
             },
+            ...locationMeta,
         },
         {
             match: {
@@ -313,6 +348,7 @@ const bridgeRoutes = target => {
                 ],
             },
             route: action,
+            ...locationMeta,
         },
         // any other method on a known target
         {

--- a/ConnectionBridge/adapter/index.js
+++ b/ConnectionBridge/adapter/index.js
@@ -373,7 +373,10 @@ const routeConfiguration = targets => ({
                         { safe_regex: { regex: '.*' } },
                     ],
                     allow_methods: 'GET, HEAD, POST, PATCH, OPTIONS',
-                    allow_headers: 'content-type,authorization',
+                    // Request-Timeout: NMOS clients (e.g. nmos-js Query /
+                    // DNS-SD) send this on long-poll style requests; not
+                    // CORS-safelisted. See sony/nmos-js@6d0e783.
+                    allow_headers: 'content-type,authorization,request-timeout',
                 },
             },
             routes: [

--- a/ConnectionBridge/adapter/index.js
+++ b/ConnectionBridge/adapter/index.js
@@ -267,17 +267,22 @@ const directResponse = (status, error) => ({
 });
 
 const bridgeRoutes = target => {
-    const prefix = `${BRIDGE_PREFIX}/devices/${target.deviceId}/connection/${target.version}/`;
+    // path_separated_prefix matches the version path exactly or with a
+    // following '/...' (Envoy 1.22+; compose pins v1.31). That preserves
+    // whatever the client sent after the version (nothing, '/', or a
+    // sub-path) when rewriting onto the Device Connection API basePath,
+    // so trailing-slash handling stays with the upstream per IS-04/IS-05.
+    const pathPrefix = `${BRIDGE_PREFIX}/devices/${target.deviceId}/connection/${target.version}`;
     const action = {
         cluster: clusterName(target),
-        prefix_rewrite: `${target.basePath}/`,
+        prefix_rewrite: target.basePath,
         timeout: `${ROUTE_TIMEOUT_SECONDS}s`,
     };
     return [
         // GETs may be retried, POSTs and PATCHes must not be
         {
             match: {
-                prefix,
+                path_separated_prefix: pathPrefix,
                 headers: [{ name: ':method', string_match: { exact: 'GET' } }],
             },
             route: {
@@ -290,7 +295,7 @@ const bridgeRoutes = target => {
         },
         {
             match: {
-                prefix,
+                path_separated_prefix: pathPrefix,
                 headers: [
                     {
                         name: ':method',
@@ -304,7 +309,7 @@ const bridgeRoutes = target => {
         },
         // any other method on a known target
         {
-            match: { prefix },
+            match: { path_separated_prefix: pathPrefix },
             ...directResponse(405, 'Method not allowed'),
         },
     ];

--- a/ConnectionBridge/adapter/index.js
+++ b/ConnectionBridge/adapter/index.js
@@ -279,11 +279,18 @@ const bridgeRoutes = target => {
         timeout: `${ROUTE_TIMEOUT_SECONDS}s`,
     };
     return [
-        // GETs may be retried, POSTs and PATCHes must not be
+        // GET and HEAD may be retried; POSTs and PATCHes must not be
         {
             match: {
                 path_separated_prefix: pathPrefix,
-                headers: [{ name: ':method', string_match: { exact: 'GET' } }],
+                headers: [
+                    {
+                        name: ':method',
+                        string_match: {
+                            safe_regex: { regex: 'GET|HEAD' },
+                        },
+                    },
+                ],
             },
             route: {
                 ...action,
@@ -329,7 +336,7 @@ const routeConfiguration = targets => ({
                     allow_origin_string_match: [
                         { safe_regex: { regex: '.*' } },
                     ],
-                    allow_methods: 'GET, POST, PATCH, OPTIONS',
+                    allow_methods: 'GET, HEAD, POST, PATCH, OPTIONS',
                     allow_headers: 'content-type,authorization',
                 },
             },

--- a/ConnectionBridge/docker-compose.yml
+++ b/ConnectionBridge/docker-compose.yml
@@ -9,9 +9,15 @@ services:
     build: ./adapter
     restart: unless-stopped
     environment:
-      # the Query API used to discover Devices, also routed at /x-nmos/
+      # Query API used to discover Devices; also upstream for /x-nmos/query/
+      # (and /x-dns-sd/, /log/ unless overridden below)
       REGISTRY_QUERY_URL: http://registry:8870/x-nmos/query/v1.3
-      # optional: serve the nmos-js app through Envoy too, at /
+      # optional: different host/port for /x-dns-sd/ (default: same as Query)
+      # REGISTRY_DNS_SD_URL: http://registry:3208
+      # optional: different host/port for /log/ (default: same as Query)
+      # REGISTRY_LOGGING_URL: http://registry:5106
+      # optional: serve the UI through Envoy too (catch-all /)
+      # standalone nmos-js (SPA at /), or a Registry (UI under /admin)
       APP_URL: http://nmos-js:80
     volumes:
       - envoy-dynamic:/etc/envoy/dynamic

--- a/ConnectionBridge/docker-compose.yml
+++ b/ConnectionBridge/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - "8080:8080"
     volumes:
       - ./envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro
+      - ./envoy/location_rewrite.lua:/etc/envoy/location_rewrite.lua:ro
       - envoy-dynamic:/etc/envoy/dynamic
 
 volumes:

--- a/ConnectionBridge/envoy/envoy.yaml
+++ b/ConnectionBridge/envoy/envoy.yaml
@@ -61,6 +61,22 @@ static_resources:
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.buffer.v3.Buffer
                       max_request_bytes: 1048576
+                  # Per-route LuaPerRoute (from the adapter) writes Location
+                  # rewrite context into dynamic metadata. Default is a no-op.
+                  - name: nmos.bridge.location_meta
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                      default_source_code:
+                        inline_string: |
+                          function envoy_on_request(request_handle)
+                          end
+                  # rewrite Device / path-absolute Location on upstream 3xx
+                  # onto the bridge (see location_rewrite.lua)
+                  - name: envoy.filters.http.lua
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                      default_source_code:
+                        filename: /etc/envoy/location_rewrite.lua
                   - name: envoy.filters.http.router
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/ConnectionBridge/envoy/location_rewrite.lua
+++ b/ConnectionBridge/envoy/location_rewrite.lua
@@ -29,9 +29,12 @@
 -- (LuaPerRoute from the adapter).
 --
 -- Structure: generic URL/string helpers, then bridge-specific helpers, then
--- policy (handle_location) and Envoy entry points. Envoy Lua has no URL
--- library, so most of the file is RFC-oriented parse/resolve support.
+-- policy (handle_location) and Envoy entry points. Pure helpers are exported
+-- via the module return value for unit tests; Envoy loads this file for the
+-- global envoy_on_* entry points and ignores the return. Envoy Lua has no URL
+-- library, so most of the file is RFC 3986-oriented parse/resolve support.
 
+local M = {}
 local DYN = "nmos_bridge_location"
 
 -- ---------------------------------------------------------------------------
@@ -105,19 +108,33 @@ local function path_suffix_after(pathquery, prefix)
     return nil
 end
 
--- RFC 3986 remove_dot_segments (path only).
+-- RFC 3986 §5.2.4 remove_dot_segments (path only).
 local function remove_dot_segments(path)
+    -- 1. The input buffer is initialized with the now-appended path
+    --    components and the output buffer is initialized to the empty
+    --    string.
     local input = path
     local output = {}
+    -- 2. While the input buffer is not empty, loop as follows:
     while input ~= "" do
+        -- A. If the input buffer begins with a prefix of "../" or "./",
+        --    then remove that prefix from the input buffer; otherwise,
         if input:sub(1, 3) == "../" then
             input = input:sub(4)
         elseif input:sub(1, 2) == "./" then
             input = input:sub(3)
+        -- B. if the input buffer begins with a prefix of "/./" or "/.",
+        --    where "." is a complete path segment, then replace that
+        --    prefix with "/" in the input buffer; otherwise,
         elseif input:sub(1, 3) == "/./" then
             input = "/" .. input:sub(4)
         elseif input == "/." then
             input = "/"
+        -- C. if the input buffer begins with a prefix of "/../" or "/..",
+        --    where ".." is a complete path segment, then replace that
+        --    prefix with "/" in the input buffer and remove the last
+        --    segment and its preceding "/" (if any) from the output
+        --    buffer; otherwise,
         elseif input:sub(1, 4) == "/../" then
             input = "/" .. input:sub(5)
             if #output > 0 then
@@ -128,14 +145,16 @@ local function remove_dot_segments(path)
             if #output > 0 then
                 table.remove(output)
             end
+        -- D. if the input buffer consists only of "." or "..", then remove
+        --    that from the input buffer; otherwise,
         elseif input == "." or input == ".." then
             input = ""
-        elseif input == "/" then
-            -- preserve a trailing slash (final empty segment)
-            table.insert(output, "/")
-            input = ""
+        -- E. move the first path segment in the input buffer to the end of
+        --    the output buffer, including the initial "/" character (if
+        --    any) and any subsequent characters up to, but not including,
+        --    the next "/" character or the end of the input buffer.
         else
-            local seg, rest = input:match("^(/?[^/]+)(.*)$")
+            local seg, rest = input:match("^(/?[^/]*)(.*)$")
             if not seg then
                 break
             end
@@ -143,6 +162,7 @@ local function remove_dot_segments(path)
             input = rest
         end
     end
+    -- 3. Finally, the output buffer is returned as the result.
     return table.concat(output)
 end
 
@@ -403,3 +423,13 @@ function envoy_on_response(response_handle)
         response_handle:headers():replace("location", result)
     end
 end
+
+-- Pure helpers (Envoy entry points stay global; reject_unsupported needs handles).
+M.path_suffix_after = path_suffix_after
+M.remove_dot_segments = remove_dot_segments
+M.resolve_path_relative = resolve_path_relative
+M.parse_absolute = parse_absolute
+M.rewrite_onto_bridge = rewrite_onto_bridge
+M.handle_location = handle_location
+
+return M

--- a/ConnectionBridge/envoy/location_rewrite.lua
+++ b/ConnectionBridge/envoy/location_rewrite.lua
@@ -21,8 +21,9 @@
 --   candidate Envoy selected).
 --
 -- Envoy internal redirects are not used: they require a fully qualified
--- Location and then re-select a route by path, so Device absolutes under
--- /x-nmos/ would hit the Registry cluster.
+-- Location and then re-select a route by path. A Device path such as
+-- /x-nmos/connection/... would not match a bridge route under
+-- /x-nmos-bridge/... (and would not hit the Query API cluster either).
 --
 -- Per-route context is set into dynamic metadata namespace
 -- nmos_bridge_location by the nmos.bridge.location_meta Lua filter

--- a/ConnectionBridge/envoy/location_rewrite.lua
+++ b/ConnectionBridge/envoy/location_rewrite.lua
@@ -267,7 +267,8 @@ local function reject_unsupported(response_handle, location)
     response_handle:headers():replace("content-type", "application/json")
     response_handle:headers():add("x-nmos-bridge-error", header_safe(msg))
     response_handle:headers():remove("location")
-    response_handle:body():setBytes(body)
+    -- always_wrap_body: an upstream 3xx typically has no body to wrap
+    response_handle:body(true):setBytes(body)
 end
 
 -- ---------------------------------------------------------------------------

--- a/ConnectionBridge/envoy/location_rewrite.lua
+++ b/ConnectionBridge/envoy/location_rewrite.lua
@@ -267,8 +267,10 @@ local function reject_unsupported(response_handle, location)
     response_handle:headers():replace("content-type", "application/json")
     response_handle:headers():add("x-nmos-bridge-error", header_safe(msg))
     response_handle:headers():remove("location")
-    -- always_wrap_body: an upstream 3xx typically has no body to wrap
-    response_handle:body(true):setBytes(body)
+    -- always_wrap_body: an upstream 3xx typically has no body to wrap.
+    -- setBytes does not update Content-Length; set it from the returned size.
+    local content_length = response_handle:body(true):setBytes(body)
+    response_handle:headers():replace("content-length", content_length)
 end
 
 -- ---------------------------------------------------------------------------

--- a/ConnectionBridge/envoy/location_rewrite.lua
+++ b/ConnectionBridge/envoy/location_rewrite.lua
@@ -1,0 +1,405 @@
+-- Handle Connection API Bridge upstream 3xx Location headers.
+--
+-- Relative Location values are resolved against the reconstructed upstream
+-- request path (base_path + suffix of the downstream bridge path). That path
+-- is the same for every candidate of a target. Clients must not see Locations
+-- that only make sense relative to the Device URL.
+--
+-- Policy:
+-- - Path-relative or root-relative (path-absolute) whose resolved path is
+--   under this target's Connection API base_path: rewrite onto the bridge.
+-- - Absolute http(s) (or scheme-relative resolved with the client scheme)
+--   whose host/port matches a candidate and whose path is under base_path:
+--   rewrite onto the bridge (client scheme/host/port).
+-- - Absolute http(s) / scheme-relative for any other authority, or a matching
+--   candidate whose path is outside base_path: leave unchanged (the Location
+--   already names a precise URL).
+-- - Path-relative or root-relative outside base_path: replace the response
+--   with 502 and NMOS error JSON; set
+--   x-nmos-bridge-error: unsupported upstream location: <location>
+--   (an absolute Device URL cannot be reconstructed without knowing which
+--   candidate Envoy selected).
+--
+-- Envoy internal redirects are not used: they require a fully qualified
+-- Location and then re-select a route by path, so Device absolutes under
+-- /x-nmos/ would hit the Registry cluster.
+--
+-- Per-route context is set into dynamic metadata namespace
+-- nmos_bridge_location by the nmos.bridge.location_meta Lua filter
+-- (LuaPerRoute from the adapter).
+--
+-- Structure: generic URL/string helpers, then bridge-specific helpers, then
+-- policy (handle_location) and Envoy entry points. Envoy Lua has no URL
+-- library, so most of the file is RFC-oriented parse/resolve support.
+
+local DYN = "nmos_bridge_location"
+
+-- ---------------------------------------------------------------------------
+-- Generic URL / string helpers (no bridge policy)
+-- ---------------------------------------------------------------------------
+
+local function split_host_port(host, scheme)
+    local default_port = (scheme == "https") and "443" or "80"
+    local h, p = host:match("^%[([^%]]+)%]:(%d+)$")
+    if h then
+        return h, p
+    end
+    h = host:match("^%[([^%]]+)%]$")
+    if h then
+        return h, default_port
+    end
+    h, p = host:match("^([^:]+):(%d+)$")
+    if h then
+        return h, p
+    end
+    return host, default_port
+end
+
+local function parse_authority_pathquery(rest, default_scheme)
+    local authority, pathquery = rest:match("^([^/?#]+)(.*)$")
+    if not authority then
+        return nil
+    end
+    if pathquery == nil or pathquery == "" then
+        pathquery = "/"
+    end
+    local host, port = split_host_port(authority, default_scheme)
+    return host, port, pathquery
+end
+
+local function parse_absolute(url)
+    local s_flag, rest = url:match("^[Hh][Tt][Tt][Pp]([Ss]?)://(.+)$")
+    if not rest then
+        return nil
+    end
+    local scheme = (s_flag ~= nil and s_flag ~= "") and "https" or "http"
+    local host, port, pathquery = parse_authority_pathquery(rest, scheme)
+    if not host then
+        return nil
+    end
+    return scheme, host, port, pathquery
+end
+
+local function split_path_rest(pathquery)
+    local path, rest = pathquery:match("^([^?#]*)(.*)$")
+    if path == nil then
+        return nil, nil
+    end
+    return path, rest
+end
+
+-- If path equals prefix or is prefix/..., return (suffix, query/fragment).
+-- suffix is "" or "/...". Otherwise nil.
+local function path_suffix_after(pathquery, prefix)
+    local path, rest = split_path_rest(pathquery)
+    if path == nil then
+        return nil
+    end
+    if path == prefix then
+        return "", rest
+    end
+    local with_slash = prefix .. "/"
+    if path:sub(1, #with_slash) == with_slash then
+        return path:sub(#prefix + 1), rest
+    end
+    return nil
+end
+
+-- RFC 3986 remove_dot_segments (path only).
+local function remove_dot_segments(path)
+    local input = path
+    local output = {}
+    while input ~= "" do
+        if input:sub(1, 3) == "../" then
+            input = input:sub(4)
+        elseif input:sub(1, 2) == "./" then
+            input = input:sub(3)
+        elseif input:sub(1, 3) == "/./" then
+            input = "/" .. input:sub(4)
+        elseif input == "/." then
+            input = "/"
+        elseif input:sub(1, 4) == "/../" then
+            input = "/" .. input:sub(5)
+            if #output > 0 then
+                table.remove(output)
+            end
+        elseif input == "/.." then
+            input = "/"
+            if #output > 0 then
+                table.remove(output)
+            end
+        elseif input == "." or input == ".." then
+            input = ""
+        elseif input == "/" then
+            -- preserve a trailing slash (final empty segment)
+            table.insert(output, "/")
+            input = ""
+        else
+            local seg, rest = input:match("^(/?[^/]+)(.*)$")
+            if not seg then
+                break
+            end
+            table.insert(output, seg)
+            input = rest
+        end
+    end
+    return table.concat(output)
+end
+
+-- Resolve a path-relative reference against a path (no query/fragment on the
+-- base for merge; ref may carry ?/#).
+local function resolve_path_relative(base_path, reference)
+    local ref_path, ref_rest = split_path_rest(reference)
+    if ref_path == nil then
+        return nil
+    end
+    local base_dir = base_path:match("^(.*)/") or ""
+    local merged = base_dir .. "/" .. ref_path
+    return remove_dot_segments(merged) .. (ref_rest or "")
+end
+
+local function header_safe(value)
+    return (value:gsub("[\r\n]", ""))
+end
+
+-- Escape a string for inclusion in a JSON string value.
+local function json_string(value)
+    local out = {}
+    for i = 1, #value do
+        local c = value:sub(i, i)
+        local b = string.byte(c)
+        if c == "\\" then
+            table.insert(out, "\\\\")
+        elseif c == '"' then
+            table.insert(out, '\\"')
+        elseif c == "\b" then
+            table.insert(out, "\\b")
+        elseif c == "\f" then
+            table.insert(out, "\\f")
+        elseif c == "\n" then
+            table.insert(out, "\\n")
+        elseif c == "\r" then
+            table.insert(out, "\\r")
+        elseif c == "\t" then
+            table.insert(out, "\\t")
+        elseif b < 0x20 then
+            table.insert(out, string.format("\\u%04x", b))
+        else
+            table.insert(out, c)
+        end
+    end
+    return table.concat(out)
+end
+
+-- ---------------------------------------------------------------------------
+-- Bridge-specific helpers
+-- ---------------------------------------------------------------------------
+
+local function authority_key(host, port)
+    return host:lower() .. ":" .. port
+end
+
+local function matches_upstream(
+    loc_scheme,
+    loc_host,
+    loc_port,
+    upstream_scheme,
+    upstream_authorities
+)
+    if loc_scheme ~= upstream_scheme then
+        return false
+    end
+    local want = authority_key(loc_host, loc_port)
+    for entry in string.gmatch(upstream_authorities, "[^,]+") do
+        local host, port = split_host_port(entry, upstream_scheme)
+        if authority_key(host, port) == want then
+            return true
+        end
+    end
+    return false
+end
+
+-- Reconstruct the upstream request path from the downstream bridge path.
+local function upstream_path_from_downstream(downstream_path, bridge_path, base_path)
+    if downstream_path == nil or downstream_path == "" then
+        return base_path
+    end
+    local suffix = path_suffix_after(downstream_path, bridge_path)
+    if suffix == nil then
+        return base_path
+    end
+    return base_path .. suffix
+end
+
+local function rewrite_onto_bridge(pathquery, base_path, bridge_path)
+    local suffix, rest = path_suffix_after(pathquery, base_path)
+    if suffix == nil then
+        return nil
+    end
+    return bridge_path .. suffix .. rest
+end
+
+local function reject_unsupported(response_handle, location)
+    local msg = "unsupported upstream location: " .. location
+    local body =
+        '{"code":502,"error":"' .. json_string(msg) .. '","debug":null}'
+    response_handle:headers():replace(":status", "502")
+    response_handle:headers():replace("content-type", "application/json")
+    response_handle:headers():add("x-nmos-bridge-error", header_safe(msg))
+    response_handle:headers():remove("location")
+    response_handle:body():setBytes(body)
+end
+
+-- ---------------------------------------------------------------------------
+-- Policy
+-- ---------------------------------------------------------------------------
+
+-- Returns rewritten Location string, "reject", or nil to leave unchanged.
+local function handle_location(
+    location,
+    base_path,
+    bridge_path,
+    bridge_scheme,
+    bridge_host,
+    upstream_scheme,
+    upstream_authorities,
+    downstream_path
+)
+    if location == nil or location == "" then
+        return nil
+    end
+
+    -- root-relative (path-absolute)
+    if location:sub(1, 1) == "/" and location:sub(2, 2) ~= "/" then
+        local rewritten = rewrite_onto_bridge(location, base_path, bridge_path)
+        if rewritten ~= nil then
+            return rewritten
+        end
+        return "reject"
+    end
+
+    -- path-relative (no scheme; not scheme-relative)
+    if location:sub(1, 2) ~= "//" and not location:match("^[A-Za-z][A-Za-z0-9+.-]*:") then
+        local up_path =
+            upstream_path_from_downstream(downstream_path, bridge_path, base_path)
+        local resolved = resolve_path_relative(up_path, location)
+        if resolved == nil then
+            return "reject"
+        end
+        local rewritten = rewrite_onto_bridge(resolved, base_path, bridge_path)
+        if rewritten ~= nil then
+            return rewritten
+        end
+        return "reject"
+    end
+
+    -- scheme-relative: fill scheme from the downstream request, then absolute
+    local absolute = location
+    if location:sub(1, 2) == "//" then
+        absolute = bridge_scheme .. ":" .. location
+    elseif not location:lower():match("^https?://") then
+        -- non-http(s) absolute
+        return "reject"
+    end
+
+    local loc_scheme, loc_host, loc_port, pathquery = parse_absolute(absolute)
+    if not loc_scheme then
+        return "reject"
+    end
+    if
+        not matches_upstream(
+            loc_scheme,
+            loc_host,
+            loc_port,
+            upstream_scheme,
+            upstream_authorities
+        )
+    then
+        -- foreign absolute / scheme-relative: leave the original Location
+        return nil
+    end
+    local rewritten = rewrite_onto_bridge(pathquery, base_path, bridge_path)
+    if rewritten == nil then
+        -- candidate authority but path outside Connection API base: the
+        -- Location already names a precise URL (e.g. /x-manifest/)
+        return nil
+    end
+    return bridge_scheme .. "://" .. bridge_host .. rewritten
+end
+
+-- ---------------------------------------------------------------------------
+-- Envoy entry points
+-- ---------------------------------------------------------------------------
+
+function envoy_on_request(request_handle)
+    local headers = request_handle:headers()
+    local host = headers:get(":authority") or headers:get("host")
+    local path = headers:get(":path")
+    local scheme = headers:get("x-forwarded-proto")
+    if scheme == nil or scheme == "" then
+        scheme = headers:get(":scheme")
+    end
+    if scheme == nil or scheme == "" then
+        scheme = "http"
+    end
+    if host == nil or host == "" then
+        return
+    end
+    local md = request_handle:streamInfo():dynamicMetadata()
+    md:set(DYN, "host", host)
+    md:set(DYN, "scheme", scheme)
+    if path ~= nil and path ~= "" then
+        md:set(DYN, "path", path)
+    end
+end
+
+function envoy_on_response(response_handle)
+    local status = tonumber(response_handle:headers():get(":status"))
+    if status == nil or status < 300 or status >= 400 then
+        return
+    end
+    local location = response_handle:headers():get("location")
+    if location == nil or location == "" then
+        return
+    end
+
+    local dyn = response_handle:streamInfo():dynamicMetadata():get(DYN)
+    if dyn == nil then
+        return
+    end
+    local base_path = dyn["base_path"]
+    local bridge_path = dyn["bridge_path"]
+    local upstream_scheme = dyn["upstream_scheme"]
+    local upstream_authorities = dyn["upstream_authorities"]
+    local bridge_host = dyn["host"]
+    local bridge_scheme = dyn["scheme"]
+    local downstream_path = dyn["path"]
+    if
+        base_path == nil
+        or bridge_path == nil
+        or upstream_scheme == nil
+        or upstream_authorities == nil
+        or bridge_host == nil
+        or bridge_scheme == nil
+    then
+        return
+    end
+
+    local result = handle_location(
+        location,
+        base_path,
+        bridge_path,
+        bridge_scheme,
+        bridge_host,
+        upstream_scheme,
+        upstream_authorities,
+        downstream_path
+    )
+    if result == "reject" then
+        reject_unsupported(response_handle, location)
+        return
+    end
+    if result ~= nil and result ~= location then
+        response_handle:headers():replace("location", result)
+    end
+end

--- a/ConnectionBridge/envoy/location_rewrite_test.lua
+++ b/ConnectionBridge/envoy/location_rewrite_test.lua
@@ -1,0 +1,299 @@
+-- Unit tests for location_rewrite.lua (Lua 5.1 / LuaJIT).
+-- Run from this directory: lua5.1 location_rewrite_test.lua
+
+local rewrite = require("location_rewrite")
+
+local failures = 0
+
+local function fail(msg)
+    failures = failures + 1
+    io.stderr:write("FAIL: " .. msg .. "\n")
+end
+
+local function assert_eq(expected, actual, label)
+    if actual ~= expected then
+        fail(
+            string.format(
+                "%s\n  expected: %s\n  actual:   %s",
+                label,
+                tostring(expected),
+                tostring(actual)
+            )
+        )
+    end
+end
+
+local function assert_nil(actual, label)
+    if actual ~= nil then
+        fail(string.format("%s\n  expected: nil\n  actual:   %s", label, tostring(actual)))
+    end
+end
+
+-- ---------------------------------------------------------------------------
+-- Helpers
+-- ---------------------------------------------------------------------------
+
+do
+    local suffix, rest = rewrite.path_suffix_after(
+        "/x-nmos/connection/v1.1/single/receivers/r1",
+        "/x-nmos/connection/v1.1"
+    )
+    assert_eq("/single/receivers/r1", suffix, "path_suffix_after under prefix")
+    assert_eq("", rest, "path_suffix_after no query")
+end
+
+do
+    local suffix, rest = rewrite.path_suffix_after(
+        "/x-nmos/connection/v1.1?x=1",
+        "/x-nmos/connection/v1.1"
+    )
+    assert_eq("", suffix, "path_suffix_after exact path")
+    assert_eq("?x=1", rest, "path_suffix_after keeps query")
+end
+
+assert_nil(
+    rewrite.path_suffix_after("/x-manifest/foo", "/x-nmos/connection/v1.1"),
+    "path_suffix_after outside prefix"
+)
+
+-- RFC 3986 §5.2.4 worked examples
+assert_eq("/a/g", rewrite.remove_dot_segments("/a/b/c/./../../g"), "RFC 3986 §5.2.4 /a/b/c/./../../g")
+assert_eq("mid/6", rewrite.remove_dot_segments("mid/content=5/../6"), "RFC 3986 §5.2.4 mid/content=5/../6")
+-- Empty segments (segment = *pchar) and trailing slash via 2E
+assert_eq("/a/b/", rewrite.remove_dot_segments("/a/b/"), "remove_dot_segments trailing slash")
+assert_eq("/a/b//c", rewrite.remove_dot_segments("/a/b//c"), "remove_dot_segments mid-path empty segment")
+assert_eq("//", rewrite.remove_dot_segments("//"), "remove_dot_segments two empty segments")
+assert_eq("/a/", rewrite.remove_dot_segments("/a/b//c/../../.."), "remove_dot_segments empty segment then ..")
+assert_eq("/a/c", rewrite.remove_dot_segments("/a/b/../c"), "remove_dot_segments ..")
+assert_eq("/", rewrite.remove_dot_segments("/."), "remove_dot_segments /.")
+assert_eq("/", rewrite.remove_dot_segments("/.."), "remove_dot_segments /..")
+-- §5.4.2 path-absolute abnormal (remove_dot_segments only)
+assert_eq("/g", rewrite.remove_dot_segments("/./g"), "RFC 3986 §5.4.2 /./g")
+assert_eq("/g", rewrite.remove_dot_segments("/../g"), "RFC 3986 §5.4.2 /../g")
+
+-- RFC 3986 §5.4.1 / §5.4.2 path-relative examples (base URI http://a/b/c/d;p?q).
+-- Assert path + query/fragment only (no scheme/host). Skip scheme, authority,
+-- path-absolute, query-only, fragment-only, and empty-reference rows.
+local RFC3986_BASE_PATH = "/b/c/d;p"
+
+local function assert_resolve(ref, expected_pathquery, label)
+    assert_eq(
+        expected_pathquery,
+        rewrite.resolve_path_relative(RFC3986_BASE_PATH, ref),
+        label
+    )
+end
+
+-- §5.4.1 Normal Examples (path-relative subset)
+assert_resolve("g", "/b/c/g", "RFC 3986 §5.4.1 g")
+assert_resolve("./g", "/b/c/g", "RFC 3986 §5.4.1 ./g")
+assert_resolve("g/", "/b/c/g/", "RFC 3986 §5.4.1 g/")
+assert_resolve("g?y", "/b/c/g?y", "RFC 3986 §5.4.1 g?y")
+assert_resolve("g#s", "/b/c/g#s", "RFC 3986 §5.4.1 g#s")
+assert_resolve("g?y#s", "/b/c/g?y#s", "RFC 3986 §5.4.1 g?y#s")
+assert_resolve(";x", "/b/c/;x", "RFC 3986 §5.4.1 ;x")
+assert_resolve("g;x", "/b/c/g;x", "RFC 3986 §5.4.1 g;x")
+assert_resolve("g;x?y#s", "/b/c/g;x?y#s", "RFC 3986 §5.4.1 g;x?y#s")
+assert_resolve(".", "/b/c/", "RFC 3986 §5.4.1 .")
+assert_resolve("./", "/b/c/", "RFC 3986 §5.4.1 ./")
+assert_resolve("..", "/b/", "RFC 3986 §5.4.1 ..")
+assert_resolve("../", "/b/", "RFC 3986 §5.4.1 ../")
+assert_resolve("../g", "/b/g", "RFC 3986 §5.4.1 ../g")
+assert_resolve("../..", "/", "RFC 3986 §5.4.1 ../..")
+assert_resolve("../../", "/", "RFC 3986 §5.4.1 ../../")
+assert_resolve("../../g", "/g", "RFC 3986 §5.4.1 ../../g")
+
+-- §5.4.2 Abnormal Examples (path-relative subset + query/fragment isolation)
+assert_resolve("../../../g", "/g", "RFC 3986 §5.4.2 ../../../g")
+assert_resolve("../../../../g", "/g", "RFC 3986 §5.4.2 ../../../../g")
+assert_resolve("g.", "/b/c/g.", "RFC 3986 §5.4.2 g.")
+assert_resolve(".g", "/b/c/.g", "RFC 3986 §5.4.2 .g")
+assert_resolve("g..", "/b/c/g..", "RFC 3986 §5.4.2 g..")
+assert_resolve("..g", "/b/c/..g", "RFC 3986 §5.4.2 ..g")
+assert_resolve("./../g", "/b/g", "RFC 3986 §5.4.2 ./../g")
+assert_resolve("./g/.", "/b/c/g/", "RFC 3986 §5.4.2 ./g/.")
+assert_resolve("g/./h", "/b/c/g/h", "RFC 3986 §5.4.2 g/./h")
+assert_resolve("g/../h", "/b/c/h", "RFC 3986 §5.4.2 g/../h")
+assert_resolve("g;x=1/./y", "/b/c/g;x=1/y", "RFC 3986 §5.4.2 g;x=1/./y")
+assert_resolve("g;x=1/../y", "/b/c/y", "RFC 3986 §5.4.2 g;x=1/../y")
+assert_resolve("g?y/./x", "/b/c/g?y/./x", "RFC 3986 §5.4.2 g?y/./x")
+assert_resolve("g?y/../x", "/b/c/g?y/../x", "RFC 3986 §5.4.2 g?y/../x")
+assert_resolve("g#s/./x", "/b/c/g#s/./x", "RFC 3986 §5.4.2 g#s/./x")
+assert_resolve("g#s/../x", "/b/c/g#s/../x", "RFC 3986 §5.4.2 g#s/../x")
+
+-- Bridge-oriented resolve checks (same helper)
+assert_eq(
+    "/x-nmos/connection/v1.1/single/receivers/r1/active",
+    rewrite.resolve_path_relative("/x-nmos/connection/v1.1/single/receivers/r1/staged", "active"),
+    "resolve_path_relative sibling"
+)
+assert_eq(
+    "/x-nmos/connection/v1.1/single/senders/s1",
+    rewrite.resolve_path_relative("/x-nmos/connection/v1.1/single/receivers/r1/staged", "../../senders/s1"),
+    "resolve_path_relative up"
+)
+
+do
+    local scheme, host, port, pathquery =
+        rewrite.parse_absolute("HTTP://Device.Example:8080/x-nmos/connection/v1.1/foo")
+    assert_eq("http", scheme, "parse_absolute scheme")
+    assert_eq("Device.Example", host, "parse_absolute host")
+    assert_eq("8080", port, "parse_absolute port")
+    assert_eq("/x-nmos/connection/v1.1/foo", pathquery, "parse_absolute path")
+end
+
+assert_nil(select(1, rewrite.parse_absolute("http://")), "parse_absolute empty authority")
+assert_nil(select(1, rewrite.parse_absolute("http:///path")), "parse_absolute missing authority")
+assert_nil(select(1, rewrite.parse_absolute("not-a-url")), "parse_absolute no scheme")
+
+assert_eq(
+    "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1/single/receivers/r1",
+    rewrite.rewrite_onto_bridge(
+        "/x-nmos/connection/v1.1/single/receivers/r1",
+        "/x-nmos/connection/v1.1",
+        "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1"
+    ),
+    "rewrite_onto_bridge in-base"
+)
+assert_nil(
+    rewrite.rewrite_onto_bridge(
+        "/x-manifest/foo",
+        "/x-nmos/connection/v1.1",
+        "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1"
+    ),
+    "rewrite_onto_bridge out-of-base"
+)
+
+-- ---------------------------------------------------------------------------
+-- handle_location policy
+-- ---------------------------------------------------------------------------
+
+local BASE = "/x-nmos/connection/v1.1"
+local BRIDGE = "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1"
+local DOWN =
+    "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1/single/receivers/r1/staged"
+local AUTHS = "device.local:80,10.0.0.5:80"
+
+local function handle(location, extras)
+    extras = extras or {}
+    return rewrite.handle_location(
+        location,
+        extras.base_path or BASE,
+        extras.bridge_path or BRIDGE,
+        extras.bridge_scheme or "http",
+        extras.bridge_host or "controller.example:8080",
+        extras.upstream_scheme or "http",
+        extras.upstream_authorities or AUTHS,
+        extras.downstream_path or DOWN
+    )
+end
+
+assert_nil(handle(nil), "empty: nil location")
+assert_nil(handle(""), "empty: empty string")
+
+assert_eq(
+    BRIDGE .. "/single/receivers/r1/active",
+    handle("/x-nmos/connection/v1.1/single/receivers/r1/active"),
+    "root-relative in-base -> bridge path"
+)
+assert_eq(BRIDGE, handle(BASE), "root-relative exact base_path -> bridge path")
+assert_eq(
+    BRIDGE .. "/single/receivers/r1/active?x=1",
+    handle("/x-nmos/connection/v1.1/single/receivers/r1/active?x=1"),
+    "root-relative in-base preserves query"
+)
+assert_eq("reject", handle("/x-manifest/stream"), "root-relative out-of-base -> reject")
+
+assert_eq(
+    BRIDGE .. "/single/receivers/r1/active",
+    handle("active"),
+    "path-relative sibling -> bridge"
+)
+assert_eq(
+    "reject",
+    handle("../../../../../x-manifest/foo"),
+    "path-relative escapes Connection API base -> reject"
+)
+
+assert_eq(
+    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
+    handle("http://device.local/x-nmos/connection/v1.1/single/receivers/r1/active"),
+    "absolute candidate in-base -> bridge absolute"
+)
+assert_eq(
+    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active?x=1",
+    handle("http://device.local/x-nmos/connection/v1.1/single/receivers/r1/active?x=1"),
+    "absolute candidate in-base preserves query"
+)
+assert_eq(
+    "http://controller.example:8080" .. BRIDGE .. "/single/senders/s1",
+    handle("http://10.0.0.5/x-nmos/connection/v1.1/single/senders/s1"),
+    "absolute other candidate in-base -> bridge absolute"
+)
+assert_eq(
+    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
+    handle(
+        "http://device.local:80/x-nmos/connection/v1.1/single/receivers/r1/active",
+        { upstream_authorities = "device.local" }
+    ),
+    "absolute explicit :80 matches authority without port"
+)
+assert_eq(
+    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
+    handle("http://Device.Local/x-nmos/connection/v1.1/single/receivers/r1/active"),
+    "absolute candidate host match is case-insensitive"
+)
+assert_eq(
+    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
+    handle(
+        "http://[2001:db8::1]/x-nmos/connection/v1.1/single/receivers/r1/active",
+        { upstream_authorities = "[2001:db8::1]:80" }
+    ),
+    "absolute IPv6 candidate in-base -> bridge absolute"
+)
+assert_nil(
+    handle("http://foreign.example/x-nmos/connection/v1.1/single/receivers/r1"),
+    "foreign absolute -> leave unchanged"
+)
+assert_nil(
+    handle("http://device.local/x-manifest/foo"),
+    "candidate absolute outside base -> leave unchanged"
+)
+assert_eq(
+    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
+    handle("//device.local/x-nmos/connection/v1.1/single/receivers/r1/active"),
+    "scheme-relative candidate in-base uses client scheme"
+)
+assert_eq(
+    "https://controller.example" .. BRIDGE .. "/single/receivers/r1/active",
+    handle(
+        "//device.local/x-nmos/connection/v1.1/single/receivers/r1/active",
+        {
+            bridge_scheme = "https",
+            bridge_host = "controller.example",
+            upstream_scheme = "https",
+            upstream_authorities = "device.local:443",
+        }
+    ),
+    "scheme-relative with https client and https upstream"
+)
+assert_nil(
+    handle(
+        "//device.local/x-nmos/connection/v1.1/single/receivers/r1/active",
+        { bridge_scheme = "https", bridge_host = "controller.example" }
+    ),
+    "scheme-relative https client vs http upstream -> leave unchanged"
+)
+assert_nil(
+    handle("https://device.local/x-nmos/connection/v1.1/single/receivers/r1"),
+    "https absolute when upstream is http -> leave unchanged"
+)
+assert_eq("reject", handle("ftp://device.local/foo"), "non-http(s) absolute -> reject")
+assert_eq("reject", handle("http://"), "malformed absolute -> reject")
+assert_eq("reject", handle("http:///x-nmos/connection/v1.1/"), "absolute missing authority -> reject")
+
+if failures > 0 then
+    io.stderr:write(string.format("%d failure(s)\n", failures))
+    os.exit(1)
+end
+print("ok")

--- a/ConnectionBridge/envoy/location_rewrite_test.lua
+++ b/ConnectionBridge/envoy/location_rewrite_test.lua
@@ -1,13 +1,36 @@
 -- Unit tests for location_rewrite.lua (Lua 5.1 / LuaJIT).
--- Run from this directory: lua5.1 location_rewrite_test.lua
+-- Run from this directory:
+--   lua5.1 location_rewrite_test.lua
+--   lua5.1 location_rewrite_test.lua -v
 
 local rewrite = require("location_rewrite")
 
+local verbose = os.getenv("VERBOSE") == "1"
+if arg then
+    for i = 1, #arg do
+        if arg[i] == "-v" or arg[i] == "--verbose" then
+            verbose = true
+        end
+    end
+end
+
 local failures = 0
+local tests_run = 0
+local tests_failed = 0
+-- When non-nil, soft-fail lines are buffered until the current test() finishes
+-- so verbose status ("... ok" / "... FAILED") prints before FAIL details.
+-- All harness output goes to stdout (like cargo test).
+local pending_fails = nil
 
 local function fail(msg)
     failures = failures + 1
-    io.stderr:write("FAIL: " .. msg .. "\n")
+    local line = "FAIL: " .. msg .. "\n"
+    if pending_fails then
+        pending_fails[#pending_fails + 1] = line
+    else
+        io.write(line)
+        io.flush()
+    end
 end
 
 local function assert_eq(expected, actual, label)
@@ -29,47 +52,83 @@ local function assert_nil(actual, label)
     end
 end
 
+local function test(name, fn)
+    tests_run = tests_run + 1
+    if verbose then
+        io.write("test " .. name .. " ... ")
+        io.flush()
+        pending_fails = {}
+    end
+    local before = failures
+    local ok, err = pcall(fn)
+    if not ok then
+        fail(name .. ": " .. tostring(err))
+    end
+    local failed = failures > before
+    if failed then
+        tests_failed = tests_failed + 1
+    end
+    if verbose then
+        io.write(failed and "FAILED\n" or "ok\n")
+        for i = 1, #pending_fails do
+            io.write(pending_fails[i])
+        end
+        io.flush()
+        pending_fails = nil
+    end
+end
+
 -- ---------------------------------------------------------------------------
 -- Helpers
 -- ---------------------------------------------------------------------------
 
-do
+test("path_suffix_after_under_prefix", function()
     local suffix, rest = rewrite.path_suffix_after(
         "/x-nmos/connection/v1.1/single/receivers/r1",
         "/x-nmos/connection/v1.1"
     )
     assert_eq("/single/receivers/r1", suffix, "path_suffix_after under prefix")
     assert_eq("", rest, "path_suffix_after no query")
-end
+end)
 
-do
+test("path_suffix_after_exact_path", function()
     local suffix, rest = rewrite.path_suffix_after(
         "/x-nmos/connection/v1.1?x=1",
         "/x-nmos/connection/v1.1"
     )
     assert_eq("", suffix, "path_suffix_after exact path")
     assert_eq("?x=1", rest, "path_suffix_after keeps query")
-end
+end)
 
-assert_nil(
-    rewrite.path_suffix_after("/x-manifest/foo", "/x-nmos/connection/v1.1"),
-    "path_suffix_after outside prefix"
-)
+test("path_suffix_after_outside_prefix", function()
+    assert_nil(
+        rewrite.path_suffix_after("/x-manifest/foo", "/x-nmos/connection/v1.1"),
+        "path_suffix_after outside prefix"
+    )
+end)
 
 -- RFC 3986 §5.2.4 worked examples
-assert_eq("/a/g", rewrite.remove_dot_segments("/a/b/c/./../../g"), "RFC 3986 §5.2.4 /a/b/c/./../../g")
-assert_eq("mid/6", rewrite.remove_dot_segments("mid/content=5/../6"), "RFC 3986 §5.2.4 mid/content=5/../6")
+test("rfc3986_5_2_4_dot_segments", function()
+    assert_eq("/a/g", rewrite.remove_dot_segments("/a/b/c/./../../g"), "RFC 3986 §5.2.4 /a/b/c/./../../g")
+    assert_eq("mid/6", rewrite.remove_dot_segments("mid/content=5/../6"), "RFC 3986 §5.2.4 mid/content=5/../6")
+end)
+
 -- Empty segments (segment = *pchar) and trailing slash via 2E
-assert_eq("/a/b/", rewrite.remove_dot_segments("/a/b/"), "remove_dot_segments trailing slash")
-assert_eq("/a/b//c", rewrite.remove_dot_segments("/a/b//c"), "remove_dot_segments mid-path empty segment")
-assert_eq("//", rewrite.remove_dot_segments("//"), "remove_dot_segments two empty segments")
-assert_eq("/a/", rewrite.remove_dot_segments("/a/b//c/../../.."), "remove_dot_segments empty segment then ..")
-assert_eq("/a/c", rewrite.remove_dot_segments("/a/b/../c"), "remove_dot_segments ..")
-assert_eq("/", rewrite.remove_dot_segments("/."), "remove_dot_segments /.")
-assert_eq("/", rewrite.remove_dot_segments("/.."), "remove_dot_segments /..")
+test("remove_dot_segments_empty_and_trailing", function()
+    assert_eq("/a/b/", rewrite.remove_dot_segments("/a/b/"), "remove_dot_segments trailing slash")
+    assert_eq("/a/b//c", rewrite.remove_dot_segments("/a/b//c"), "remove_dot_segments mid-path empty segment")
+    assert_eq("//", rewrite.remove_dot_segments("//"), "remove_dot_segments two empty segments")
+    assert_eq("/a/", rewrite.remove_dot_segments("/a/b//c/../../.."), "remove_dot_segments empty segment then ..")
+    assert_eq("/a/c", rewrite.remove_dot_segments("/a/b/../c"), "remove_dot_segments ..")
+    assert_eq("/", rewrite.remove_dot_segments("/."), "remove_dot_segments /.")
+    assert_eq("/", rewrite.remove_dot_segments("/.."), "remove_dot_segments /..")
+end)
+
 -- §5.4.2 path-absolute abnormal (remove_dot_segments only)
-assert_eq("/g", rewrite.remove_dot_segments("/./g"), "RFC 3986 §5.4.2 /./g")
-assert_eq("/g", rewrite.remove_dot_segments("/../g"), "RFC 3986 §5.4.2 /../g")
+test("rfc3986_5_4_2_path_absolute_abnormal", function()
+    assert_eq("/g", rewrite.remove_dot_segments("/./g"), "RFC 3986 §5.4.2 /./g")
+    assert_eq("/g", rewrite.remove_dot_segments("/../g"), "RFC 3986 §5.4.2 /../g")
+end)
 
 -- RFC 3986 §5.4.1 / §5.4.2 path-relative examples (base URI http://a/b/c/d;p?q).
 -- Assert path + query/fragment only (no scheme/host). Skip scheme, authority,
@@ -85,84 +144,94 @@ local function assert_resolve(ref, expected_pathquery, label)
 end
 
 -- §5.4.1 Normal Examples (path-relative subset)
-assert_resolve("g", "/b/c/g", "RFC 3986 §5.4.1 g")
-assert_resolve("./g", "/b/c/g", "RFC 3986 §5.4.1 ./g")
-assert_resolve("g/", "/b/c/g/", "RFC 3986 §5.4.1 g/")
-assert_resolve("g?y", "/b/c/g?y", "RFC 3986 §5.4.1 g?y")
-assert_resolve("g#s", "/b/c/g#s", "RFC 3986 §5.4.1 g#s")
-assert_resolve("g?y#s", "/b/c/g?y#s", "RFC 3986 §5.4.1 g?y#s")
-assert_resolve(";x", "/b/c/;x", "RFC 3986 §5.4.1 ;x")
-assert_resolve("g;x", "/b/c/g;x", "RFC 3986 §5.4.1 g;x")
-assert_resolve("g;x?y#s", "/b/c/g;x?y#s", "RFC 3986 §5.4.1 g;x?y#s")
-assert_resolve(".", "/b/c/", "RFC 3986 §5.4.1 .")
-assert_resolve("./", "/b/c/", "RFC 3986 §5.4.1 ./")
-assert_resolve("..", "/b/", "RFC 3986 §5.4.1 ..")
-assert_resolve("../", "/b/", "RFC 3986 §5.4.1 ../")
-assert_resolve("../g", "/b/g", "RFC 3986 §5.4.1 ../g")
-assert_resolve("../..", "/", "RFC 3986 §5.4.1 ../..")
-assert_resolve("../../", "/", "RFC 3986 §5.4.1 ../../")
-assert_resolve("../../g", "/g", "RFC 3986 §5.4.1 ../../g")
+test("rfc3986_5_4_1_normal_path_relative", function()
+    assert_resolve("g", "/b/c/g", "RFC 3986 §5.4.1 g")
+    assert_resolve("./g", "/b/c/g", "RFC 3986 §5.4.1 ./g")
+    assert_resolve("g/", "/b/c/g/", "RFC 3986 §5.4.1 g/")
+    assert_resolve("g?y", "/b/c/g?y", "RFC 3986 §5.4.1 g?y")
+    assert_resolve("g#s", "/b/c/g#s", "RFC 3986 §5.4.1 g#s")
+    assert_resolve("g?y#s", "/b/c/g?y#s", "RFC 3986 §5.4.1 g?y#s")
+    assert_resolve(";x", "/b/c/;x", "RFC 3986 §5.4.1 ;x")
+    assert_resolve("g;x", "/b/c/g;x", "RFC 3986 §5.4.1 g;x")
+    assert_resolve("g;x?y#s", "/b/c/g;x?y#s", "RFC 3986 §5.4.1 g;x?y#s")
+    assert_resolve(".", "/b/c/", "RFC 3986 §5.4.1 .")
+    assert_resolve("./", "/b/c/", "RFC 3986 §5.4.1 ./")
+    assert_resolve("..", "/b/", "RFC 3986 §5.4.1 ..")
+    assert_resolve("../", "/b/", "RFC 3986 §5.4.1 ../")
+    assert_resolve("../g", "/b/g", "RFC 3986 §5.4.1 ../g")
+    assert_resolve("../..", "/", "RFC 3986 §5.4.1 ../..")
+    assert_resolve("../../", "/", "RFC 3986 §5.4.1 ../../")
+    assert_resolve("../../g", "/g", "RFC 3986 §5.4.1 ../../g")
+end)
 
 -- §5.4.2 Abnormal Examples (path-relative subset + query/fragment isolation)
-assert_resolve("../../../g", "/g", "RFC 3986 §5.4.2 ../../../g")
-assert_resolve("../../../../g", "/g", "RFC 3986 §5.4.2 ../../../../g")
-assert_resolve("g.", "/b/c/g.", "RFC 3986 §5.4.2 g.")
-assert_resolve(".g", "/b/c/.g", "RFC 3986 §5.4.2 .g")
-assert_resolve("g..", "/b/c/g..", "RFC 3986 §5.4.2 g..")
-assert_resolve("..g", "/b/c/..g", "RFC 3986 §5.4.2 ..g")
-assert_resolve("./../g", "/b/g", "RFC 3986 §5.4.2 ./../g")
-assert_resolve("./g/.", "/b/c/g/", "RFC 3986 §5.4.2 ./g/.")
-assert_resolve("g/./h", "/b/c/g/h", "RFC 3986 §5.4.2 g/./h")
-assert_resolve("g/../h", "/b/c/h", "RFC 3986 §5.4.2 g/../h")
-assert_resolve("g;x=1/./y", "/b/c/g;x=1/y", "RFC 3986 §5.4.2 g;x=1/./y")
-assert_resolve("g;x=1/../y", "/b/c/y", "RFC 3986 §5.4.2 g;x=1/../y")
-assert_resolve("g?y/./x", "/b/c/g?y/./x", "RFC 3986 §5.4.2 g?y/./x")
-assert_resolve("g?y/../x", "/b/c/g?y/../x", "RFC 3986 §5.4.2 g?y/../x")
-assert_resolve("g#s/./x", "/b/c/g#s/./x", "RFC 3986 §5.4.2 g#s/./x")
-assert_resolve("g#s/../x", "/b/c/g#s/../x", "RFC 3986 §5.4.2 g#s/../x")
+test("rfc3986_5_4_2_abnormal_path_relative", function()
+    assert_resolve("../../../g", "/g", "RFC 3986 §5.4.2 ../../../g")
+    assert_resolve("../../../../g", "/g", "RFC 3986 §5.4.2 ../../../../g")
+    assert_resolve("g.", "/b/c/g.", "RFC 3986 §5.4.2 g.")
+    assert_resolve(".g", "/b/c/.g", "RFC 3986 §5.4.2 .g")
+    assert_resolve("g..", "/b/c/g..", "RFC 3986 §5.4.2 g..")
+    assert_resolve("..g", "/b/c/..g", "RFC 3986 §5.4.2 ..g")
+    assert_resolve("./../g", "/b/g", "RFC 3986 §5.4.2 ./../g")
+    assert_resolve("./g/.", "/b/c/g/", "RFC 3986 §5.4.2 ./g/.")
+    assert_resolve("g/./h", "/b/c/g/h", "RFC 3986 §5.4.2 g/./h")
+    assert_resolve("g/../h", "/b/c/h", "RFC 3986 §5.4.2 g/../h")
+    assert_resolve("g;x=1/./y", "/b/c/g;x=1/y", "RFC 3986 §5.4.2 g;x=1/./y")
+    assert_resolve("g;x=1/../y", "/b/c/y", "RFC 3986 §5.4.2 g;x=1/../y")
+    assert_resolve("g?y/./x", "/b/c/g?y/./x", "RFC 3986 §5.4.2 g?y/./x")
+    assert_resolve("g?y/../x", "/b/c/g?y/../x", "RFC 3986 §5.4.2 g?y/../x")
+    assert_resolve("g#s/./x", "/b/c/g#s/./x", "RFC 3986 §5.4.2 g#s/./x")
+    assert_resolve("g#s/../x", "/b/c/g#s/../x", "RFC 3986 §5.4.2 g#s/../x")
+end)
 
 -- Bridge-oriented resolve checks (same helper)
-assert_eq(
-    "/x-nmos/connection/v1.1/single/receivers/r1/active",
-    rewrite.resolve_path_relative("/x-nmos/connection/v1.1/single/receivers/r1/staged", "active"),
-    "resolve_path_relative sibling"
-)
-assert_eq(
-    "/x-nmos/connection/v1.1/single/senders/s1",
-    rewrite.resolve_path_relative("/x-nmos/connection/v1.1/single/receivers/r1/staged", "../../senders/s1"),
-    "resolve_path_relative up"
-)
+test("resolve_path_relative_bridge_oriented", function()
+    assert_eq(
+        "/x-nmos/connection/v1.1/single/receivers/r1/active",
+        rewrite.resolve_path_relative("/x-nmos/connection/v1.1/single/receivers/r1/staged", "active"),
+        "resolve_path_relative sibling"
+    )
+    assert_eq(
+        "/x-nmos/connection/v1.1/single/senders/s1",
+        rewrite.resolve_path_relative("/x-nmos/connection/v1.1/single/receivers/r1/staged", "../../senders/s1"),
+        "resolve_path_relative up"
+    )
+end)
 
-do
+test("parse_absolute_http", function()
     local scheme, host, port, pathquery =
         rewrite.parse_absolute("HTTP://Device.Example:8080/x-nmos/connection/v1.1/foo")
     assert_eq("http", scheme, "parse_absolute scheme")
     assert_eq("Device.Example", host, "parse_absolute host")
     assert_eq("8080", port, "parse_absolute port")
     assert_eq("/x-nmos/connection/v1.1/foo", pathquery, "parse_absolute path")
-end
+end)
 
-assert_nil(select(1, rewrite.parse_absolute("http://")), "parse_absolute empty authority")
-assert_nil(select(1, rewrite.parse_absolute("http:///path")), "parse_absolute missing authority")
-assert_nil(select(1, rewrite.parse_absolute("not-a-url")), "parse_absolute no scheme")
+test("parse_absolute_rejects", function()
+    assert_nil(select(1, rewrite.parse_absolute("http://")), "parse_absolute empty authority")
+    assert_nil(select(1, rewrite.parse_absolute("http:///path")), "parse_absolute missing authority")
+    assert_nil(select(1, rewrite.parse_absolute("not-a-url")), "parse_absolute no scheme")
+end)
 
-assert_eq(
-    "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1/single/receivers/r1",
-    rewrite.rewrite_onto_bridge(
-        "/x-nmos/connection/v1.1/single/receivers/r1",
-        "/x-nmos/connection/v1.1",
-        "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1"
-    ),
-    "rewrite_onto_bridge in-base"
-)
-assert_nil(
-    rewrite.rewrite_onto_bridge(
-        "/x-manifest/foo",
-        "/x-nmos/connection/v1.1",
-        "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1"
-    ),
-    "rewrite_onto_bridge out-of-base"
-)
+test("rewrite_onto_bridge", function()
+    assert_eq(
+        "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1/single/receivers/r1",
+        rewrite.rewrite_onto_bridge(
+            "/x-nmos/connection/v1.1/single/receivers/r1",
+            "/x-nmos/connection/v1.1",
+            "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1"
+        ),
+        "rewrite_onto_bridge in-base"
+    )
+    assert_nil(
+        rewrite.rewrite_onto_bridge(
+            "/x-manifest/foo",
+            "/x-nmos/connection/v1.1",
+            "/x-nmos-bridge/v1.0/devices/d1/connection/v1.1"
+        ),
+        "rewrite_onto_bridge out-of-base"
+    )
+end)
 
 -- ---------------------------------------------------------------------------
 -- handle_location policy
@@ -188,109 +257,126 @@ local function handle(location, extras)
     )
 end
 
-assert_nil(handle(nil), "empty: nil location")
-assert_nil(handle(""), "empty: empty string")
+test("handle_location_empty", function()
+    assert_nil(handle(nil), "empty: nil location")
+    assert_nil(handle(""), "empty: empty string")
+end)
 
-assert_eq(
-    BRIDGE .. "/single/receivers/r1/active",
-    handle("/x-nmos/connection/v1.1/single/receivers/r1/active"),
-    "root-relative in-base -> bridge path"
-)
-assert_eq(BRIDGE, handle(BASE), "root-relative exact base_path -> bridge path")
-assert_eq(
-    BRIDGE .. "/single/receivers/r1/active?x=1",
-    handle("/x-nmos/connection/v1.1/single/receivers/r1/active?x=1"),
-    "root-relative in-base preserves query"
-)
-assert_eq("reject", handle("/x-manifest/stream"), "root-relative out-of-base -> reject")
+test("handle_location_root_relative", function()
+    assert_eq(
+        BRIDGE .. "/single/receivers/r1/active",
+        handle("/x-nmos/connection/v1.1/single/receivers/r1/active"),
+        "root-relative in-base -> bridge path"
+    )
+    assert_eq(BRIDGE, handle(BASE), "root-relative exact base_path -> bridge path")
+    assert_eq(
+        BRIDGE .. "/single/receivers/r1/active?x=1",
+        handle("/x-nmos/connection/v1.1/single/receivers/r1/active?x=1"),
+        "root-relative in-base preserves query"
+    )
+    assert_eq("reject", handle("/x-manifest/stream"), "root-relative out-of-base -> reject")
+end)
 
-assert_eq(
-    BRIDGE .. "/single/receivers/r1/active",
-    handle("active"),
-    "path-relative sibling -> bridge"
-)
-assert_eq(
-    "reject",
-    handle("../../../../../x-manifest/foo"),
-    "path-relative escapes Connection API base -> reject"
-)
+test("handle_location_path_relative", function()
+    assert_eq(
+        BRIDGE .. "/single/receivers/r1/active",
+        handle("active"),
+        "path-relative sibling -> bridge"
+    )
+    assert_eq(
+        "reject",
+        handle("../../../../../x-manifest/foo"),
+        "path-relative escapes Connection API base -> reject"
+    )
+end)
 
-assert_eq(
-    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
-    handle("http://device.local/x-nmos/connection/v1.1/single/receivers/r1/active"),
-    "absolute candidate in-base -> bridge absolute"
-)
-assert_eq(
-    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active?x=1",
-    handle("http://device.local/x-nmos/connection/v1.1/single/receivers/r1/active?x=1"),
-    "absolute candidate in-base preserves query"
-)
-assert_eq(
-    "http://controller.example:8080" .. BRIDGE .. "/single/senders/s1",
-    handle("http://10.0.0.5/x-nmos/connection/v1.1/single/senders/s1"),
-    "absolute other candidate in-base -> bridge absolute"
-)
-assert_eq(
-    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
-    handle(
-        "http://device.local:80/x-nmos/connection/v1.1/single/receivers/r1/active",
-        { upstream_authorities = "device.local" }
-    ),
-    "absolute explicit :80 matches authority without port"
-)
-assert_eq(
-    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
-    handle("http://Device.Local/x-nmos/connection/v1.1/single/receivers/r1/active"),
-    "absolute candidate host match is case-insensitive"
-)
-assert_eq(
-    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
-    handle(
-        "http://[2001:db8::1]/x-nmos/connection/v1.1/single/receivers/r1/active",
-        { upstream_authorities = "[2001:db8::1]:80" }
-    ),
-    "absolute IPv6 candidate in-base -> bridge absolute"
-)
-assert_nil(
-    handle("http://foreign.example/x-nmos/connection/v1.1/single/receivers/r1"),
-    "foreign absolute -> leave unchanged"
-)
-assert_nil(
-    handle("http://device.local/x-manifest/foo"),
-    "candidate absolute outside base -> leave unchanged"
-)
-assert_eq(
-    "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
-    handle("//device.local/x-nmos/connection/v1.1/single/receivers/r1/active"),
-    "scheme-relative candidate in-base uses client scheme"
-)
-assert_eq(
-    "https://controller.example" .. BRIDGE .. "/single/receivers/r1/active",
-    handle(
-        "//device.local/x-nmos/connection/v1.1/single/receivers/r1/active",
-        {
-            bridge_scheme = "https",
-            bridge_host = "controller.example",
-            upstream_scheme = "https",
-            upstream_authorities = "device.local:443",
-        }
-    ),
-    "scheme-relative with https client and https upstream"
-)
-assert_nil(
-    handle(
-        "//device.local/x-nmos/connection/v1.1/single/receivers/r1/active",
-        { bridge_scheme = "https", bridge_host = "controller.example" }
-    ),
-    "scheme-relative https client vs http upstream -> leave unchanged"
-)
-assert_nil(
-    handle("https://device.local/x-nmos/connection/v1.1/single/receivers/r1"),
-    "https absolute when upstream is http -> leave unchanged"
-)
-assert_eq("reject", handle("ftp://device.local/foo"), "non-http(s) absolute -> reject")
-assert_eq("reject", handle("http://"), "malformed absolute -> reject")
-assert_eq("reject", handle("http:///x-nmos/connection/v1.1/"), "absolute missing authority -> reject")
+test("handle_location_absolute_candidate", function()
+    assert_eq(
+        "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
+        handle("http://device.local/x-nmos/connection/v1.1/single/receivers/r1/active"),
+        "absolute candidate in-base -> bridge absolute"
+    )
+    assert_eq(
+        "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active?x=1",
+        handle("http://device.local/x-nmos/connection/v1.1/single/receivers/r1/active?x=1"),
+        "absolute candidate in-base preserves query"
+    )
+    assert_eq(
+        "http://controller.example:8080" .. BRIDGE .. "/single/senders/s1",
+        handle("http://10.0.0.5/x-nmos/connection/v1.1/single/senders/s1"),
+        "absolute other candidate in-base -> bridge absolute"
+    )
+    assert_eq(
+        "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
+        handle(
+            "http://device.local:80/x-nmos/connection/v1.1/single/receivers/r1/active",
+            { upstream_authorities = "device.local" }
+        ),
+        "absolute explicit :80 matches authority without port"
+    )
+    assert_eq(
+        "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
+        handle("http://Device.Local/x-nmos/connection/v1.1/single/receivers/r1/active"),
+        "absolute candidate host match is case-insensitive"
+    )
+    assert_eq(
+        "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
+        handle(
+            "http://[2001:db8::1]/x-nmos/connection/v1.1/single/receivers/r1/active",
+            { upstream_authorities = "[2001:db8::1]:80" }
+        ),
+        "absolute IPv6 candidate in-base -> bridge absolute"
+    )
+end)
+
+test("handle_location_absolute_leave_unchanged", function()
+    assert_nil(
+        handle("http://foreign.example/x-nmos/connection/v1.1/single/receivers/r1"),
+        "foreign absolute -> leave unchanged"
+    )
+    assert_nil(
+        handle("http://device.local/x-manifest/foo"),
+        "candidate absolute outside base -> leave unchanged"
+    )
+end)
+
+test("handle_location_scheme_relative", function()
+    assert_eq(
+        "http://controller.example:8080" .. BRIDGE .. "/single/receivers/r1/active",
+        handle("//device.local/x-nmos/connection/v1.1/single/receivers/r1/active"),
+        "scheme-relative candidate in-base uses client scheme"
+    )
+    assert_eq(
+        "https://controller.example" .. BRIDGE .. "/single/receivers/r1/active",
+        handle(
+            "//device.local/x-nmos/connection/v1.1/single/receivers/r1/active",
+            {
+                bridge_scheme = "https",
+                bridge_host = "controller.example",
+                upstream_scheme = "https",
+                upstream_authorities = "device.local:443",
+            }
+        ),
+        "scheme-relative with https client and https upstream"
+    )
+    assert_nil(
+        handle(
+            "//device.local/x-nmos/connection/v1.1/single/receivers/r1/active",
+            { bridge_scheme = "https", bridge_host = "controller.example" }
+        ),
+        "scheme-relative https client vs http upstream -> leave unchanged"
+    )
+end)
+
+test("handle_location_scheme_and_malformed", function()
+    assert_nil(
+        handle("https://device.local/x-nmos/connection/v1.1/single/receivers/r1"),
+        "https absolute when upstream is http -> leave unchanged"
+    )
+    assert_eq("reject", handle("ftp://device.local/foo"), "non-http(s) absolute -> reject")
+    assert_eq("reject", handle("http://"), "malformed absolute -> reject")
+    assert_eq("reject", handle("http:///x-nmos/connection/v1.1/"), "absolute missing authority -> reject")
+end)
 
 -- ---------------------------------------------------------------------------
 -- Envoy entry points (mock handles)
@@ -400,7 +486,7 @@ local function run_response(response)
     end
 end
 
-do
+test("envoy_on_request_stores_metadata", function()
     local metadata = {}
     envoy_on_request(mock_request_handle({
         [":authority"] = "controller.example:8080",
@@ -411,9 +497,9 @@ do
     assert_eq("controller.example:8080", dyn.host, "envoy_on_request stores host")
     assert_eq("http", dyn.scheme, "envoy_on_request stores scheme")
     assert_eq(DOWN, dyn.path, "envoy_on_request stores path")
-end
+end)
 
-do
+test("envoy_on_request_prefers_x_forwarded_proto", function()
     local metadata = {}
     envoy_on_request(mock_request_handle({
         [":authority"] = "controller.example:8080",
@@ -426,10 +512,10 @@ do
         metadata["nmos_bridge_location"].scheme,
         "envoy_on_request prefers x-forwarded-proto over :scheme"
     )
-end
+end)
 
 -- Host only (no :authority) — HTTP/1.1 style
-do
+test("envoy_on_request_falls_back_to_host", function()
     local metadata = {}
     envoy_on_request(mock_request_handle({
         ["Host"] = "controller.example:8080",
@@ -441,10 +527,10 @@ do
         metadata["nmos_bridge_location"].host,
         "envoy_on_request falls back to Host"
     )
-end
+end)
 
 -- Prefer :authority when both are present
-do
+test("envoy_on_request_prefers_authority_over_host", function()
     local metadata = {}
     envoy_on_request(mock_request_handle({
         [":authority"] = "controller.example:8080",
@@ -457,20 +543,20 @@ do
         metadata["nmos_bridge_location"].host,
         "envoy_on_request prefers :authority over Host"
     )
-end
+end)
 
 -- Empty / missing host → early return, no metadata written
-do
+test("envoy_on_request_skips_empty_host", function()
     local metadata = {}
     envoy_on_request(mock_request_handle({
         [":path"] = DOWN,
         [":scheme"] = "http",
     }, metadata))
     assert_nil(metadata["nmos_bridge_location"], "envoy_on_request skips empty host")
-end
+end)
 
 -- in-base root-relative Location on a body-less 307 -> rewritten in place
-do
+test("envoy_on_response_rewrites_in_base_location", function()
     local response = mock_response_handle({
         [":status"] = "307",
         ["location"] = BASE .. "/single/receivers/r1/active",
@@ -483,11 +569,11 @@ do
         "rewrite maps Location onto the bridge"
     )
     assert_nil(response.body_written, "rewrite leaves the body alone")
-end
+end)
 
 -- reject path on a body-less 307: redirects typically carry no body, and
 -- Envoy's body() returns nil then unless called with always_wrap_body
-do
+test("envoy_on_response_reject_bodyless_307", function()
     local expected_body =
         '{"code":502,"error":"unsupported upstream location: /x-manifest/stream","debug":null}'
     local response = mock_response_handle({
@@ -514,10 +600,10 @@ do
         response.header_data["content-length"],
         "reject body-less 307: content-length matches body"
     )
-end
+end)
 
 -- reject path when the upstream 3xx does carry a body
-do
+test("envoy_on_response_reject_307_with_body", function()
     local expected_body =
         '{"code":502,"error":"unsupported upstream location: /x-manifest/stream","debug":null}'
     local response = mock_response_handle({
@@ -537,10 +623,10 @@ do
         response.header_data["content-length"],
         "reject 307 with body: content-length matches body"
     )
-end
+end)
 
 -- non-3xx responses and responses without route metadata are left alone
-do
+test("envoy_on_response_leaves_non_3xx_alone", function()
     local response = mock_response_handle({
         [":status"] = "200",
         ["location"] = "/x-manifest/stream",
@@ -552,9 +638,9 @@ do
         response.header_data["location"],
         "non-3xx: Location untouched"
     )
-end
+end)
 
-do
+test("envoy_on_response_leaves_missing_metadata_alone", function()
     local response = mock_response_handle({
         [":status"] = "307",
         ["location"] = "/x-manifest/stream",
@@ -566,10 +652,17 @@ do
         response.header_data["location"],
         "no metadata: Location untouched"
     )
-end
+end)
 
-if failures > 0 then
-    io.stderr:write(string.format("%d failure(s)\n", failures))
+local tests_passed = tests_run - tests_failed
+if tests_failed > 0 then
+    print(
+        string.format(
+            "test result: FAILED. %d passed; %d failed",
+            tests_passed,
+            tests_failed
+        )
+    )
     os.exit(1)
 end
-print("ok")
+print(string.format("test result: ok. %d passed; 0 failed", tests_passed))

--- a/ConnectionBridge/envoy/location_rewrite_test.lua
+++ b/ConnectionBridge/envoy/location_rewrite_test.lua
@@ -428,6 +428,47 @@ do
     )
 end
 
+-- Host only (no :authority) — HTTP/1.1 style
+do
+    local metadata = {}
+    envoy_on_request(mock_request_handle({
+        ["Host"] = "controller.example:8080",
+        [":path"] = DOWN,
+        [":scheme"] = "http",
+    }, metadata))
+    assert_eq(
+        "controller.example:8080",
+        metadata["nmos_bridge_location"].host,
+        "envoy_on_request falls back to Host"
+    )
+end
+
+-- Prefer :authority when both are present
+do
+    local metadata = {}
+    envoy_on_request(mock_request_handle({
+        [":authority"] = "controller.example:8080",
+        ["host"] = "other.example:9999",
+        [":path"] = DOWN,
+        [":scheme"] = "http",
+    }, metadata))
+    assert_eq(
+        "controller.example:8080",
+        metadata["nmos_bridge_location"].host,
+        "envoy_on_request prefers :authority over Host"
+    )
+end
+
+-- Empty / missing host → early return, no metadata written
+do
+    local metadata = {}
+    envoy_on_request(mock_request_handle({
+        [":path"] = DOWN,
+        [":scheme"] = "http",
+    }, metadata))
+    assert_nil(metadata["nmos_bridge_location"], "envoy_on_request skips empty host")
+end
+
 -- in-base root-relative Location on a body-less 307 -> rewritten in place
 do
     local response = mock_response_handle({

--- a/ConnectionBridge/envoy/location_rewrite_test.lua
+++ b/ConnectionBridge/envoy/location_rewrite_test.lua
@@ -298,24 +298,31 @@ assert_eq("reject", handle("http:///x-nmos/connection/v1.1/"), "absolute missing
 
 -- Minimal mocks of the Envoy Lua handle API used by envoy_on_request and
 -- envoy_on_response. body() mimics Envoy: nil for an absent or empty body,
--- unless called with always_wrap_body.
+-- unless called with always_wrap_body. Header keys are lowercased; values are
+-- stringified on write (luaL_checkstring); add appends with a comma join.
 
 local function mock_headers(init)
     local headers = { data = {} }
     for name, value in pairs(init or {}) do
-        headers.data[name] = value
+        headers.data[string.lower(name)] = tostring(value)
     end
     function headers:get(name)
-        return self.data[name]
+        return self.data[string.lower(name)]
     end
     function headers:replace(name, value)
-        self.data[name] = value
+        self.data[string.lower(name)] = tostring(value)
     end
     function headers:add(name, value)
-        self.data[name] = value
+        local k = string.lower(name)
+        local v = tostring(value)
+        if self.data[k] then
+            self.data[k] = self.data[k] .. "," .. v
+        else
+            self.data[k] = v
+        end
     end
     function headers:remove(name)
-        self.data[name] = nil
+        self.data[string.lower(name)] = nil
     end
     return headers
 end
@@ -364,6 +371,8 @@ local function mock_response_handle(headers, metadata, body)
         return {
             setBytes = function(_, bytes)
                 response.body_written = bytes
+                -- Envoy's setBytes returns the new buffer length.
+                return #bytes
             end,
         }
     end
@@ -438,9 +447,12 @@ end
 -- reject path on a body-less 307: redirects typically carry no body, and
 -- Envoy's body() returns nil then unless called with always_wrap_body
 do
+    local expected_body =
+        '{"code":502,"error":"unsupported upstream location: /x-manifest/stream","debug":null}'
     local response = mock_response_handle({
         [":status"] = "307",
         ["location"] = "/x-manifest/stream",
+        ["content-length"] = "0",
     }, location_metadata(), nil)
     run_response(response)
     assert_eq("502", response.header_data[":status"], "reject body-less 307: 502")
@@ -455,25 +467,34 @@ do
         "reject body-less 307: error header"
     )
     assert_nil(response.header_data["location"], "reject body-less 307: Location removed")
+    assert_eq(expected_body, response.body_written, "reject body-less 307: NMOS error body")
     assert_eq(
-        '{"code":502,"error":"unsupported upstream location: /x-manifest/stream","debug":null}',
-        response.body_written,
-        "reject body-less 307: NMOS error body"
+        tostring(#expected_body),
+        response.header_data["content-length"],
+        "reject body-less 307: content-length matches body"
     )
 end
 
 -- reject path when the upstream 3xx does carry a body
 do
+    local expected_body =
+        '{"code":502,"error":"unsupported upstream location: /x-manifest/stream","debug":null}'
     local response = mock_response_handle({
         [":status"] = "307",
         ["location"] = "/x-manifest/stream",
+        ["content-length"] = "18",
     }, location_metadata(), "<html>moved</html>")
     run_response(response)
     assert_eq("502", response.header_data[":status"], "reject 307 with body: 502")
     assert_eq(
-        '{"code":502,"error":"unsupported upstream location: /x-manifest/stream","debug":null}',
+        expected_body,
         response.body_written,
         "reject 307 with body: NMOS error body"
+    )
+    assert_eq(
+        tostring(#expected_body),
+        response.header_data["content-length"],
+        "reject 307 with body: content-length matches body"
     )
 end
 

--- a/ConnectionBridge/envoy/location_rewrite_test.lua
+++ b/ConnectionBridge/envoy/location_rewrite_test.lua
@@ -292,6 +292,220 @@ assert_eq("reject", handle("ftp://device.local/foo"), "non-http(s) absolute -> r
 assert_eq("reject", handle("http://"), "malformed absolute -> reject")
 assert_eq("reject", handle("http:///x-nmos/connection/v1.1/"), "absolute missing authority -> reject")
 
+-- ---------------------------------------------------------------------------
+-- Envoy entry points (mock handles)
+-- ---------------------------------------------------------------------------
+
+-- Minimal mocks of the Envoy Lua handle API used by envoy_on_request and
+-- envoy_on_response. body() mimics Envoy: nil for an absent or empty body,
+-- unless called with always_wrap_body.
+
+local function mock_headers(init)
+    local headers = { data = {} }
+    for name, value in pairs(init or {}) do
+        headers.data[name] = value
+    end
+    function headers:get(name)
+        return self.data[name]
+    end
+    function headers:replace(name, value)
+        self.data[name] = value
+    end
+    function headers:add(name, value)
+        self.data[name] = value
+    end
+    function headers:remove(name)
+        self.data[name] = nil
+    end
+    return headers
+end
+
+local function mock_stream_info(metadata)
+    return {
+        dynamicMetadata = function()
+            return {
+                set = function(_, namespace, key, value)
+                    metadata[namespace] = metadata[namespace] or {}
+                    metadata[namespace][key] = value
+                end,
+                get = function(_, namespace)
+                    return metadata[namespace]
+                end,
+            }
+        end,
+    }
+end
+
+local function mock_request_handle(headers, metadata)
+    local wrapped = mock_headers(headers)
+    return {
+        headers = function()
+            return wrapped
+        end,
+        streamInfo = function()
+            return mock_stream_info(metadata)
+        end,
+    }
+end
+
+local function mock_response_handle(headers, metadata, body)
+    local wrapped = mock_headers(headers)
+    local response = { header_data = wrapped.data, body_written = nil }
+    response.headers = function()
+        return wrapped
+    end
+    response.streamInfo = function()
+        return mock_stream_info(metadata)
+    end
+    response.body = function(_, always_wrap_body)
+        if (body == nil or #body == 0) and not always_wrap_body then
+            return nil
+        end
+        return {
+            setBytes = function(_, bytes)
+                response.body_written = bytes
+            end,
+        }
+    end
+    return response
+end
+
+local function location_metadata()
+    return {
+        nmos_bridge_location = {
+            base_path = BASE,
+            bridge_path = BRIDGE,
+            upstream_scheme = "http",
+            upstream_authorities = AUTHS,
+            host = "controller.example:8080",
+            scheme = "http",
+            path = DOWN,
+        },
+    }
+end
+
+local function run_response(response)
+    local ok, err = pcall(envoy_on_response, response)
+    if not ok then
+        fail("envoy_on_response error: " .. tostring(err))
+    end
+end
+
+do
+    local metadata = {}
+    envoy_on_request(mock_request_handle({
+        [":authority"] = "controller.example:8080",
+        [":path"] = DOWN,
+        [":scheme"] = "http",
+    }, metadata))
+    local dyn = metadata["nmos_bridge_location"]
+    assert_eq("controller.example:8080", dyn.host, "envoy_on_request stores host")
+    assert_eq("http", dyn.scheme, "envoy_on_request stores scheme")
+    assert_eq(DOWN, dyn.path, "envoy_on_request stores path")
+end
+
+do
+    local metadata = {}
+    envoy_on_request(mock_request_handle({
+        [":authority"] = "controller.example:8080",
+        [":path"] = DOWN,
+        [":scheme"] = "http",
+        ["x-forwarded-proto"] = "https",
+    }, metadata))
+    assert_eq(
+        "https",
+        metadata["nmos_bridge_location"].scheme,
+        "envoy_on_request prefers x-forwarded-proto over :scheme"
+    )
+end
+
+-- in-base root-relative Location on a body-less 307 -> rewritten in place
+do
+    local response = mock_response_handle({
+        [":status"] = "307",
+        ["location"] = BASE .. "/single/receivers/r1/active",
+    }, location_metadata(), nil)
+    run_response(response)
+    assert_eq("307", response.header_data[":status"], "rewrite keeps 3xx status")
+    assert_eq(
+        BRIDGE .. "/single/receivers/r1/active",
+        response.header_data["location"],
+        "rewrite maps Location onto the bridge"
+    )
+    assert_nil(response.body_written, "rewrite leaves the body alone")
+end
+
+-- reject path on a body-less 307: redirects typically carry no body, and
+-- Envoy's body() returns nil then unless called with always_wrap_body
+do
+    local response = mock_response_handle({
+        [":status"] = "307",
+        ["location"] = "/x-manifest/stream",
+    }, location_metadata(), nil)
+    run_response(response)
+    assert_eq("502", response.header_data[":status"], "reject body-less 307: 502")
+    assert_eq(
+        "application/json",
+        response.header_data["content-type"],
+        "reject body-less 307: content-type"
+    )
+    assert_eq(
+        "unsupported upstream location: /x-manifest/stream",
+        response.header_data["x-nmos-bridge-error"],
+        "reject body-less 307: error header"
+    )
+    assert_nil(response.header_data["location"], "reject body-less 307: Location removed")
+    assert_eq(
+        '{"code":502,"error":"unsupported upstream location: /x-manifest/stream","debug":null}',
+        response.body_written,
+        "reject body-less 307: NMOS error body"
+    )
+end
+
+-- reject path when the upstream 3xx does carry a body
+do
+    local response = mock_response_handle({
+        [":status"] = "307",
+        ["location"] = "/x-manifest/stream",
+    }, location_metadata(), "<html>moved</html>")
+    run_response(response)
+    assert_eq("502", response.header_data[":status"], "reject 307 with body: 502")
+    assert_eq(
+        '{"code":502,"error":"unsupported upstream location: /x-manifest/stream","debug":null}',
+        response.body_written,
+        "reject 307 with body: NMOS error body"
+    )
+end
+
+-- non-3xx responses and responses without route metadata are left alone
+do
+    local response = mock_response_handle({
+        [":status"] = "200",
+        ["location"] = "/x-manifest/stream",
+    }, location_metadata(), nil)
+    run_response(response)
+    assert_eq("200", response.header_data[":status"], "non-3xx: status untouched")
+    assert_eq(
+        "/x-manifest/stream",
+        response.header_data["location"],
+        "non-3xx: Location untouched"
+    )
+end
+
+do
+    local response = mock_response_handle({
+        [":status"] = "307",
+        ["location"] = "/x-manifest/stream",
+    }, {}, nil)
+    run_response(response)
+    assert_eq("307", response.header_data[":status"], "no metadata: status untouched")
+    assert_eq(
+        "/x-manifest/stream",
+        response.header_data["location"],
+        "no metadata: Location untouched"
+    )
+end
+
 if failures > 0 then
     io.stderr:write(string.format("%d failure(s)\n", failures))
     os.exit(1)

--- a/Development/src/config.json
+++ b/Development/src/config.json
@@ -45,7 +45,9 @@
     "Auth Enabled": {
         "value": false
     },
-    "Connection Bridge": {
+    "Connection Bridge Mode": {
         "value": "disabled"
+    },
+    "Connection Bridge API": {
     }
 }

--- a/Development/src/dataProvider.js
+++ b/Development/src/dataProvider.js
@@ -15,6 +15,7 @@ import { makeBearerAuthHeader } from './authProvider';
 import {
     BRIDGE_AUTO,
     BRIDGE_FORCED,
+    CONNECTION_BRIDGE_API,
     DNSSD_API,
     LOGGING_API,
     QUERY_API,
@@ -28,12 +29,12 @@ import {
 } from './settings';
 
 // the Connection API Bridge (see ../../ConnectionBridge) makes Device
-// Connection APIs available at a well-known path on the Query API host
-// for deployments where the browser cannot reach the Device directly
+// Connection APIs available at a configured base URL for deployments where
+// the browser cannot reach the Device directly
 const bridgeAddress = (deviceId, version) =>
     concatUrl(
-        new URL(apiUrl(QUERY_API), window.location.href).origin,
-        `/x-nmos-bridge/v1.0/devices/${deviceId}/connection/${version}`
+        apiUrl(CONNECTION_BRIDGE_API),
+        `/devices/${deviceId}/connection/${version}`
     );
 
 // which access path, direct or bridge, most recently worked for each Device

--- a/Development/src/pages/settings.js
+++ b/Development/src/pages/settings.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
     Card,
     CardContent,
@@ -8,10 +9,14 @@ import {
     List,
     ListItem,
     MenuItem,
+    Paper,
     Switch,
+    Tab,
+    Tabs,
     TextField,
     withStyles,
 } from '@material-ui/core';
+import { useTheme } from '@material-ui/styles';
 import { Title } from 'react-admin';
 import {
     AUTH_API,
@@ -19,7 +24,8 @@ import {
     BRIDGE_DISABLED,
     BRIDGE_FORCED,
     CLIENT_ID,
-    CONNECTION_BRIDGE,
+    CONNECTION_BRIDGE_API,
+    CONNECTION_BRIDGE_MODE,
     DNSSD_API,
     FRIENDLY_PARAMETERS,
     IS12_BROWSER,
@@ -46,9 +52,17 @@ const StyledTextField = withStyles(theme => ({
     },
 }))(TextField);
 
+const StyledFormControl = withStyles(theme => ({
+    root: {
+        width: 450,
+        textAlign: 'left',
+    },
+}))(FormControl);
+
 const StyledDivider = withStyles(theme => ({
     root: {
         width: 450,
+        margin: theme.spacing(1, 'auto'),
     },
 }))(Divider);
 
@@ -92,9 +106,22 @@ const pagingLimits = [
 
 const selectOnFocus = event => event.target.select();
 
+const BASIC = 'basic';
+const ADVANCED = 'advanced';
+
+// Survive remount when Authorization toggles authProvider on <Admin>
+let selectedTab = BASIC;
+
 const Settings = () => {
     const [values, setValues] = useSettingsContext();
     const [useAuth, setUseAuth] = useAuthContext();
+    const [tab, setTab] = useState(selectedTab);
+
+    const theme = useTheme();
+    const tabBackgroundColor =
+        theme.palette.type === 'light'
+            ? theme.palette.grey[100]
+            : theme.palette.grey[900];
 
     const handleTextChange = name => event => {
         setValues({ ...values, [name]: event.target.value });
@@ -110,228 +137,280 @@ const Settings = () => {
 
     return (
         <div style={{ paddingTop: '24px' }}>
-            <Card>
-                <Title title={'Settings'} />
-                <CardContent align="center">
-                    <List>
-                        {!hiddenSetting(QUERY_API) && (
-                            <StyledListItem>
-                                <StyledTextField
-                                    label="Query API"
-                                    variant="filled"
-                                    value={values[QUERY_API]}
-                                    onChange={handleTextChange(QUERY_API)}
-                                    onFocus={selectOnFocus}
-                                    disabled={disabledSetting(QUERY_API)}
-                                    helperText="Used to show the registered Nodes and their sub-resources"
-                                    name="queryapi"
-                                />
-                            </StyledListItem>
-                        )}
-                        {!hiddenSetting(LOGGING_API) && (
-                            <StyledListItem>
-                                <StyledTextField
-                                    label="Logging API"
-                                    variant="filled"
-                                    value={values[LOGGING_API]}
-                                    onChange={handleTextChange(LOGGING_API)}
-                                    onFocus={selectOnFocus}
-                                    disabled={disabledSetting(LOGGING_API)}
-                                    helperText="Used to show registry Logs"
-                                />
-                            </StyledListItem>
-                        )}
-                        {!hiddenSetting(DNSSD_API) && (
-                            <StyledListItem>
-                                <StyledTextField
-                                    label="DNS-SD API"
-                                    variant="filled"
-                                    value={values[DNSSD_API]}
-                                    onChange={handleTextChange(DNSSD_API)}
-                                    onFocus={selectOnFocus}
-                                    disabled={disabledSetting(DNSSD_API)}
-                                    helperText="Used to show alternative Query APIs"
-                                />
-                            </StyledListItem>
-                        )}
-                        {!hiddenSetting(IS12_BROWSER) && (
-                            <StyledListItem>
-                                <StyledTextField
-                                    label="IS-12 Browser"
-                                    variant="filled"
-                                    value={values[IS12_BROWSER]}
-                                    onChange={handleTextChange(IS12_BROWSER)}
-                                    onFocus={selectOnFocus}
-                                    disabled={disabledSetting(IS12_BROWSER)}
-                                    helperText="Base URL of the IS-12 Device Model Browser application"
-                                />
-                            </StyledListItem>
-                        )}
-                        {!hiddenSetting(USE_RQL) && (
-                            <StyledListItem>
-                                <FormControl
-                                    variant="filled"
-                                    disabled={disabledSetting(USE_RQL)}
-                                >
-                                    <FormControlLabel
-                                        label="RQL"
-                                        name="userql"
-                                        control={
-                                            <Switch
-                                                checked={values[USE_RQL]}
-                                                onChange={handleBooleanChange(
-                                                    USE_RQL
-                                                )}
-                                                color="primary"
-                                            />
-                                        }
+            <Title title={'Settings'} />
+            <div style={{ display: 'flex' }}>
+                <Paper
+                    style={{
+                        alignSelf: 'flex-end',
+                        background: tabBackgroundColor,
+                    }}
+                >
+                    <Tabs
+                        value={tab}
+                        onChange={(event, value) => {
+                            selectedTab = value;
+                            setTab(value);
+                        }}
+                        indicatorColor="primary"
+                        textColor="primary"
+                    >
+                        <Tab label="Basic" value={BASIC} />
+                        <Tab label="Advanced" value={ADVANCED} />
+                    </Tabs>
+                </Paper>
+                <span style={{ flexGrow: 1 }} />
+            </div>
+            <div style={{ display: 'flex' }}>
+                <Card style={{ flex: '1 1 auto' }}>
+                    <CardContent align="center">
+                        <List
+                            style={{ display: tab === BASIC ? null : 'none' }}
+                        >
+                            {!hiddenSetting(QUERY_API) && (
+                                <StyledListItem>
+                                    <StyledTextField
+                                        label="Query API"
+                                        variant="filled"
+                                        value={values[QUERY_API]}
+                                        onChange={handleTextChange(QUERY_API)}
+                                        onFocus={selectOnFocus}
+                                        disabled={disabledSetting(QUERY_API)}
+                                        helperText="Used to show the registered Nodes and their sub-resources"
+                                        name="queryapi"
                                     />
-                                    <FormHelperText variant="filled">
-                                        Use Resource Query Language rather than
-                                        basic query syntax
-                                    </FormHelperText>
-                                </FormControl>
-                            </StyledListItem>
-                        )}
-                        <StyledDivider />
-                        {!hiddenSetting(USE_AUTH) && (
-                            <StyledListItem>
-                                <FormControl
-                                    variant="filled"
-                                    disabled={disabledSetting(USE_AUTH)}
-                                >
-                                    <FormControlLabel
-                                        label="Authorization"
-                                        control={
-                                            <Switch
-                                                checked={useAuth}
-                                                onChange={handleUseAuthChange()}
-                                                color="primary"
-                                            />
-                                        }
+                                </StyledListItem>
+                            )}
+                            {!hiddenSetting(LOGGING_API) && (
+                                <StyledListItem>
+                                    <StyledTextField
+                                        label="Logging API"
+                                        variant="filled"
+                                        value={values[LOGGING_API]}
+                                        onChange={handleTextChange(LOGGING_API)}
+                                        onFocus={selectOnFocus}
+                                        disabled={disabledSetting(LOGGING_API)}
+                                        helperText="Used to show registry Logs"
                                     />
-                                    <FormHelperText variant="filled">
-                                        Use IS-10 authenticated API calls
-                                    </FormHelperText>
-                                </FormControl>
-                            </StyledListItem>
-                        )}
-                        {!hiddenSetting(CLIENT_ID) && (
-                            <StyledListItem>
-                                <StyledTextField
-                                    label="Client ID"
-                                    variant="filled"
-                                    value={values[CLIENT_ID]}
-                                    onChange={handleTextChange(CLIENT_ID)}
-                                    onFocus={selectOnFocus}
-                                    disabled={
-                                        !useAuth || disabledSetting(CLIENT_ID)
-                                    }
-                                    helperText="Used by the Authentication Server to uniquely identify this client"
-                                />
-                            </StyledListItem>
-                        )}
-                        {!hiddenSetting(AUTH_API) && (
-                            <StyledListItem>
-                                <StyledTextField
-                                    label="Authorization API"
-                                    variant="filled"
-                                    value={values[AUTH_API]}
-                                    onChange={handleTextChange(AUTH_API)}
-                                    onFocus={selectOnFocus}
-                                    disabled={
-                                        !useAuth || disabledSetting(AUTH_API)
-                                    }
-                                    helperText="Authentication Server's well known endpoint"
-                                />
-                            </StyledListItem>
-                        )}
-                        <StyledDivider />
-                        {!hiddenSetting(CONNECTION_BRIDGE) && (
-                            <StyledListItem>
-                                <StyledTextField
-                                    select
-                                    label="Connection Bridge"
-                                    variant="filled"
-                                    value={values[CONNECTION_BRIDGE]}
-                                    onChange={handleTextChange(
-                                        CONNECTION_BRIDGE
-                                    )}
-                                    margin="normal"
-                                    disabled={disabledSetting(
-                                        CONNECTION_BRIDGE
-                                    )}
-                                    helperText={
-                                        'Proxy Connection API requests via the bridge at /x-nmos-bridge/v1.0 on the Query API host, when Device control endpoints are not directly reachable (Auto) or always (Forced)'
-                                    }
-                                >
-                                    {bridgeModes.map(option => (
-                                        <MenuItem
-                                            key={option.value}
-                                            value={option.value}
-                                        >
-                                            {option.label}
-                                        </MenuItem>
-                                    ))}
-                                </StyledTextField>
-                            </StyledListItem>
-                        )}
-                        <StyledDivider />
-                        {!hiddenSetting(PAGING_LIMIT) && (
-                            <StyledListItem>
-                                <StyledTextField
-                                    select
-                                    label="Paging Limit"
-                                    variant="filled"
-                                    value={values[PAGING_LIMIT]}
-                                    onChange={handleTextChange(PAGING_LIMIT)}
-                                    margin="normal"
-                                    disabled={disabledSetting(PAGING_LIMIT)}
-                                    helperText="Applied to paginated API requests for list views"
-                                >
-                                    {pagingLimits.map(option => (
-                                        <MenuItem
-                                            key={option.value}
-                                            value={option.value}
-                                        >
-                                            {option.label}
-                                        </MenuItem>
-                                    ))}
-                                </StyledTextField>
-                            </StyledListItem>
-                        )}
-                        {!hiddenSetting(FRIENDLY_PARAMETERS) && (
-                            <StyledListItem>
-                                <FormControl
-                                    variant="filled"
-                                    disabled={disabledSetting(
-                                        FRIENDLY_PARAMETERS
-                                    )}
-                                >
-                                    <FormControlLabel
-                                        control={
-                                            <Switch
-                                                checked={
-                                                    values[FRIENDLY_PARAMETERS]
-                                                }
-                                                onChange={handleBooleanChange(
-                                                    FRIENDLY_PARAMETERS
-                                                )}
-                                                color="primary"
-                                            />
-                                        }
-                                        label="Friendly Names"
+                                </StyledListItem>
+                            )}
+                            {!hiddenSetting(DNSSD_API) && (
+                                <StyledListItem>
+                                    <StyledTextField
+                                        label="DNS-SD API"
+                                        variant="filled"
+                                        value={values[DNSSD_API]}
+                                        onChange={handleTextChange(DNSSD_API)}
+                                        onFocus={selectOnFocus}
+                                        disabled={disabledSetting(DNSSD_API)}
+                                        helperText="Used to show alternative Query APIs"
                                     />
-                                    <FormHelperText>
-                                        Show friendly names rather than API
-                                        parameter values
-                                    </FormHelperText>
-                                </FormControl>
-                            </StyledListItem>
-                        )}
-                    </List>
-                </CardContent>
-            </Card>
+                                </StyledListItem>
+                            )}
+                            {!hiddenSetting(USE_RQL) && (
+                                <StyledListItem>
+                                    <StyledFormControl
+                                        variant="filled"
+                                        disabled={disabledSetting(USE_RQL)}
+                                    >
+                                        <FormControlLabel
+                                            label="RQL"
+                                            name="userql"
+                                            control={
+                                                <Switch
+                                                    checked={values[USE_RQL]}
+                                                    onChange={handleBooleanChange(
+                                                        USE_RQL
+                                                    )}
+                                                    color="primary"
+                                                />
+                                            }
+                                        />
+                                        <FormHelperText variant="filled">
+                                            Use Resource Query Language rather
+                                            than basic query syntax
+                                        </FormHelperText>
+                                    </StyledFormControl>
+                                </StyledListItem>
+                            )}
+                            {!hiddenSetting(PAGING_LIMIT) && (
+                                <StyledListItem>
+                                    <StyledTextField
+                                        select
+                                        label="Paging Limit"
+                                        variant="filled"
+                                        value={values[PAGING_LIMIT]}
+                                        onChange={handleTextChange(
+                                            PAGING_LIMIT
+                                        )}
+                                        disabled={disabledSetting(PAGING_LIMIT)}
+                                        helperText="Applied to paginated API requests for list views"
+                                    >
+                                        {pagingLimits.map(option => (
+                                            <MenuItem
+                                                key={option.value}
+                                                value={option.value}
+                                            >
+                                                {option.label}
+                                            </MenuItem>
+                                        ))}
+                                    </StyledTextField>
+                                </StyledListItem>
+                            )}
+                            {!hiddenSetting(FRIENDLY_PARAMETERS) && (
+                                <StyledListItem>
+                                    <StyledFormControl
+                                        variant="filled"
+                                        disabled={disabledSetting(
+                                            FRIENDLY_PARAMETERS
+                                        )}
+                                    >
+                                        <FormControlLabel
+                                            control={
+                                                <Switch
+                                                    checked={
+                                                        values[
+                                                            FRIENDLY_PARAMETERS
+                                                        ]
+                                                    }
+                                                    onChange={handleBooleanChange(
+                                                        FRIENDLY_PARAMETERS
+                                                    )}
+                                                    color="primary"
+                                                />
+                                            }
+                                            label="Friendly Names"
+                                        />
+                                        <FormHelperText>
+                                            Show friendly names rather than API
+                                            parameter values
+                                        </FormHelperText>
+                                    </StyledFormControl>
+                                </StyledListItem>
+                            )}
+                        </List>
+                        <List
+                            style={{
+                                display: tab === ADVANCED ? null : 'none',
+                            }}
+                        >
+                            {!hiddenSetting(USE_AUTH) && (
+                                <StyledListItem>
+                                    <StyledFormControl
+                                        variant="filled"
+                                        disabled={disabledSetting(USE_AUTH)}
+                                    >
+                                        <FormControlLabel
+                                            label="Authorization"
+                                            control={
+                                                <Switch
+                                                    checked={useAuth}
+                                                    onChange={handleUseAuthChange()}
+                                                    color="primary"
+                                                />
+                                            }
+                                        />
+                                        <FormHelperText variant="filled">
+                                            Use IS-10 authenticated API calls
+                                        </FormHelperText>
+                                    </StyledFormControl>
+                                </StyledListItem>
+                            )}
+                            {!hiddenSetting(CLIENT_ID) && (
+                                <StyledListItem>
+                                    <StyledTextField
+                                        label="Client ID"
+                                        variant="filled"
+                                        value={values[CLIENT_ID]}
+                                        onChange={handleTextChange(CLIENT_ID)}
+                                        onFocus={selectOnFocus}
+                                        disabled={
+                                            !useAuth ||
+                                            disabledSetting(CLIENT_ID)
+                                        }
+                                        helperText="Used by the Authentication Server to uniquely identify this client"
+                                    />
+                                </StyledListItem>
+                            )}
+                            {!hiddenSetting(AUTH_API) && (
+                                <StyledListItem>
+                                    <StyledTextField
+                                        label="Authorization API"
+                                        variant="filled"
+                                        value={values[AUTH_API]}
+                                        onChange={handleTextChange(AUTH_API)}
+                                        onFocus={selectOnFocus}
+                                        disabled={
+                                            !useAuth ||
+                                            disabledSetting(AUTH_API)
+                                        }
+                                        helperText="Authentication Server's well known endpoint"
+                                    />
+                                </StyledListItem>
+                            )}
+                            <StyledDivider />
+                            {!hiddenSetting(CONNECTION_BRIDGE_MODE) && (
+                                <StyledListItem>
+                                    <StyledTextField
+                                        select
+                                        label="Connection Bridge Mode"
+                                        variant="filled"
+                                        value={values[CONNECTION_BRIDGE_MODE]}
+                                        onChange={handleTextChange(
+                                            CONNECTION_BRIDGE_MODE
+                                        )}
+                                        disabled={disabledSetting(
+                                            CONNECTION_BRIDGE_MODE
+                                        )}
+                                        helperText="Proxy Connection API requests when Device endpoints are unreachable (Auto) or always (Forced)"
+                                    >
+                                        {bridgeModes.map(option => (
+                                            <MenuItem
+                                                key={option.value}
+                                                value={option.value}
+                                            >
+                                                {option.label}
+                                            </MenuItem>
+                                        ))}
+                                    </StyledTextField>
+                                </StyledListItem>
+                            )}
+                            {!hiddenSetting(CONNECTION_BRIDGE_API) && (
+                                <StyledListItem>
+                                    <StyledTextField
+                                        label="Connection Bridge API"
+                                        variant="filled"
+                                        value={values[CONNECTION_BRIDGE_API]}
+                                        onChange={handleTextChange(
+                                            CONNECTION_BRIDGE_API
+                                        )}
+                                        onFocus={selectOnFocus}
+                                        disabled={disabledSetting(
+                                            CONNECTION_BRIDGE_API
+                                        )}
+                                        helperText="Base URL for proxied Connection API requests"
+                                    />
+                                </StyledListItem>
+                            )}
+                            <StyledDivider />
+                            {!hiddenSetting(IS12_BROWSER) && (
+                                <StyledListItem>
+                                    <StyledTextField
+                                        label="IS-12 Browser"
+                                        variant="filled"
+                                        value={values[IS12_BROWSER]}
+                                        onChange={handleTextChange(
+                                            IS12_BROWSER
+                                        )}
+                                        onFocus={selectOnFocus}
+                                        disabled={disabledSetting(IS12_BROWSER)}
+                                        helperText="Base URL of the IS-12 Device Model Browser application"
+                                    />
+                                </StyledListItem>
+                            )}
+                        </List>
+                    </CardContent>
+                </Card>
+            </div>
         </div>
     );
 };

--- a/Development/src/settings.js
+++ b/Development/src/settings.js
@@ -17,7 +17,8 @@ export const CLIENT_ID = 'Client ID';
 
 export const IS12_BROWSER = 'IS-12 Browser';
 
-export const CONNECTION_BRIDGE = 'Connection Bridge';
+export const CONNECTION_BRIDGE_API = 'Connection Bridge API';
+export const CONNECTION_BRIDGE_MODE = 'Connection Bridge Mode';
 // Connection Bridge modes
 export const BRIDGE_DISABLED = 'disabled';
 export const BRIDGE_AUTO = 'auto';
@@ -43,6 +44,8 @@ const defaultUrl = api => {
             return baseUrl + '/log/v1.0';
         case QUERY_API:
             return baseUrl + '/x-nmos/query/v1.3';
+        case CONNECTION_BRIDGE_API:
+            return baseUrl + '/x-nmos-bridge/v1.0';
         case DNSSD_API:
             return baseUrl + '/x-dns-sd/v1.1';
         case AUTH_API:
@@ -126,7 +129,7 @@ export const setUsingAuth = auth => {
 
 // an unrecognized stored value falls back to the default mode
 export const connectionBridgeMode = () => {
-    const mode = getJSONSetting(CONNECTION_BRIDGE, BRIDGE_DISABLED);
+    const mode = getJSONSetting(CONNECTION_BRIDGE_MODE, BRIDGE_DISABLED);
     return [BRIDGE_DISABLED, BRIDGE_AUTO, BRIDGE_FORCED].includes(mode)
         ? mode
         : BRIDGE_DISABLED;
@@ -191,7 +194,8 @@ const useSettings = () => {
         [PAGING_LIMIT]: apiPagingLimit(QUERY_API),
         [USE_RQL]: apiUsingRql(QUERY_API),
         [FRIENDLY_PARAMETERS]: getJSONSetting(FRIENDLY_PARAMETERS, false),
-        [CONNECTION_BRIDGE]: connectionBridgeMode(),
+        [CONNECTION_BRIDGE_MODE]: connectionBridgeMode(),
+        [CONNECTION_BRIDGE_API]: apiUrl(CONNECTION_BRIDGE_API),
         [CLIENT_ID]: authClientId(),
         [AUTH_API]: apiUrl(AUTH_API),
         [IS12_BROWSER]: apiUrl(IS12_BROWSER),
@@ -208,8 +212,13 @@ const useSettings = () => {
         if (isEffective(USE_RQL)) setApiUsingRql(QUERY_API, values[USE_RQL]);
         if (isEffective(FRIENDLY_PARAMETERS))
             setJSONSetting(FRIENDLY_PARAMETERS, values[FRIENDLY_PARAMETERS]);
-        if (isEffective(CONNECTION_BRIDGE))
-            setJSONSetting(CONNECTION_BRIDGE, values[CONNECTION_BRIDGE]);
+        if (isEffective(CONNECTION_BRIDGE_MODE))
+            setJSONSetting(
+                CONNECTION_BRIDGE_MODE,
+                values[CONNECTION_BRIDGE_MODE]
+            );
+        if (isEffective(CONNECTION_BRIDGE_API))
+            setApiUrl(CONNECTION_BRIDGE_API, values[CONNECTION_BRIDGE_API]);
         if (isEffective(CLIENT_ID)) setAuthClientId(values[CLIENT_ID]);
         if (isEffective(AUTH_API)) setApiUrl(AUTH_API, values[AUTH_API]);
         if (isEffective(IS12_BROWSER))


### PR DESCRIPTION
## Summary

Fixes Connection API Bridge routing and browser-facing behaviour when proxying Device Connection APIs through Envoy:

- Match bridge routes with `path_separated_prefix` so the client path after the Connection API version (none, `/`, or a sub-path) is preserved when rewriting onto the Device `basePath`. Trailing-slash handling stays with the upstream Device per IS-04/IS-05.
- Allow `HEAD` on bridge routes like `GET` (including retries) and advertise `HEAD` in the CORS allow-methods list.
- Rewrite upstream 3xx `Location` headers so browsers stay on the bridge for Connection API redirects that remain under that target's Connection API base path. Context (base path, bridge path, upstream scheme, candidate authorities) is injected per route via `LuaPerRoute` into dynamic metadata for `location_rewrite.lua` (Envoy Lua cannot read the LB-selected upstream host; route `filter_metadata` / `request_headers_to_add` were not usable for this on Envoy 1.31).

### Location policy

- **Path-relative / root-relative** resolved against the reconstructed upstream Connection API path: rewrite onto the bridge when the result stays under `base_path`; otherwise **502** with NMOS error JSON and `x-nmos-bridge-error` (cannot re-absolutize without knowing which candidate Envoy selected).
- **Absolute** or **scheme-relative** (filled with the client scheme): if scheme+authority match a candidate and the path is under `base_path`, rewrite onto the bridge; otherwise leave unchanged (including candidate URLs outside the base path, e.g. `/x-manifest/` or a `/transportfile` target on another path).
- Envoy **internal redirects** are not used: a fully qualified Device `Location` under `/x-nmos/` would be re-matched by path onto the Registry `/x-nmos/` routes.

Upstream scheme for matching comes from the Device control `href` (Phase 1 still only allows `http:`).

## Test plan

- [x] CI / `yarn lint-check` green
- [x] Bridge: `.../connection/v1.x`, `.../v1.x/`, and `.../v1.x/single/...` all reach the Device correctly
- [x] `HEAD` on a bridge Connection API path succeeds (and is allowed by CORS)
- [x] Candidate absolute / scheme-relative `Location` **under** Connection `base_path` is rewritten onto the bridge; foreign authorities left unchanged
- [x] Path-/root-relative under Connection base → bridge path; out-of-base relatives → 502 NMOS error; candidate absolute outside base (e.g. `/x-manifest/`) left unchanged