### PR TITLE
MXL Domain ID patch fix

### DIFF
--- a/Development/src/components/makeConnection.js
+++ b/Development/src/components/makeConnection.js
@@ -26,7 +26,7 @@ const oneToOneTransportParams = {
         'connection_authorization',
         'connection_uri',
     ],
-    'urn:x-nmos:transport:mxl': ['mxl_domain_id', 'mxl_flow_id'],
+    'urn:x-nmos:transport:mxl': ['mxl_flow_id'],
 };
 
 // create an array mapping receiver leg to sender leg
@@ -142,6 +142,9 @@ const makePatchDataWithTransportParams = (data, options) => {
         case 'urn:x-nmos:transport:websocket':
             break;
         case 'urn:x-nmos:transport:mxl':
+            legMap.forEach((senderLeg, receiverLeg) => {
+                set(patchParams[receiverLeg], 'mxl_domain_id', 'auto');
+            });
             break;
         default:
             break;


### PR DESCRIPTION
- When patching in a multi-node cluster environment where flows are replicated across nodes, the MXL domain a Sender writes to may be different to the MXL domain the Receiver reads from.
- For this reason it is unsafe to patch the domain id verbatim, and instead "auto" should be used
- This assumes that there is either one MXL domain per cluster node, or at most one MXL domain per media function meaning there is never ambiguity for Receiver's when selecting which MXL domain from which to read.